### PR TITLE
Add credential manual select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Added
 - `CredentialsList.vue` now contains an option to select the VCs shared.
-- `ShareReview.vue` now contains slots allowing templates for Capabilities and Credentials List.
 - `CredentialSelect.vue` is a new component that adds a selection box to VCs.
+
+### Changed
+- `ShareReview.vue` now contains slots allowing templates for Capabilities and Credentials List.
+- `CredentialCompactBundle.vue` has a slot for replacing `CredentialSwitch.vue`.
 
 ## 18.0.0 - 2023-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-vue-wallet ChangeLog
 
+## 18.1.0 -
+
+### Added
+- `CredentialsList.vue` now contains an option to select the VCs shared.
+- `ShareReview.vue` now contains slots allowing templates for Capabilities and Credentials List.
+- `CredentialSelect.vue` is a new component that adds a selection box to VCs.
+
 ## 18.0.0 - 2023-01-24
 
 ### Changed

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -8,7 +8,7 @@
       <credential-select
         :id="credential.id"
         :selections="selectedCredentials"
-        @selectVc="handleSelect">
+        @update-selections="handleSelect">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
@@ -66,9 +66,8 @@ export default {
     };
   },
   methods: {
-    handleSelect(action) {
-      console.log('select action', action);
-      console.log('selectedCredentials', this.selectedCredentials);
+    handleSelect({selections}) {
+      this.selectedCredentials = [...selections];
     }
   }
 };

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -5,10 +5,7 @@
       :key="index"
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
-      <credential-select
-        :id="credential.id"
-        :selections="selectedCredentials"
-        @select-credentials="handleSelect">
+      <credential-select :id="credential.id">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
@@ -42,11 +39,6 @@ export default {
       type: Array,
       required: false
     },
-    selectedCredentials: {
-      default: () => [],
-      type: Array,
-      required: false
-    },
     schemaMap: {
       type: Object,
       required: true
@@ -56,7 +48,6 @@ export default {
       required: true
     }
   },
-  emits: ['select-credentials'],
   setup(props) {
     const credentials = toRef(props, 'credentials');
     const store = toRef(props, 'store');
@@ -69,11 +60,6 @@ export default {
     return {
       filteredCredentials
     };
-  },
-  methods: {
-    handleSelect({selections}) {
-      this.$emit('select-credentials', {selections});
-    }
   }
 };
 

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -25,7 +25,7 @@
 import {computedAsync} from '@vueuse/core';
 import CredentialSelect from './CredentialSelect.vue';
 import {CredentialSwitch} from '@bedrock/vue-vc';
-import {ref, toRef} from 'vue';
+import {toRef} from 'vue';
 
 export default {
   name: 'CredentialsList',
@@ -42,6 +42,11 @@ export default {
       type: Array,
       required: false
     },
+    selectedCredentials: {
+      default: () => [],
+      type: Array,
+      required: false
+    },
     schemaMap: {
       type: Object,
       required: true
@@ -51,6 +56,7 @@ export default {
       required: true
     }
   },
+  emits: ['update-selections'],
   setup(props) {
     const credentials = toRef(props, 'credentials');
     const store = toRef(props, 'store');
@@ -61,13 +67,12 @@ export default {
       return createCompactBundledCredentials({credentials: credentials.value});
     }, []);
     return {
-      selectedCredentials: ref(props.credentials.map(vc => vc.id)),
       filteredCredentials
     };
   },
   methods: {
     handleSelect({selections}) {
-      this.selectedCredentials = [...selections];
+      this.$emit('update-selections', {selections});
     }
   }
 };

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -5,14 +5,12 @@
       :key="index"
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
-      <q-checkbox
-        v-model="selected"
-        val="credential.id">
+      <credential-select>
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
           :credential="credential" />
-      </q-checkbox>
+      </credential-select>
     </div>
   </div>
 </template>
@@ -21,13 +19,15 @@
 /*!
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {reactive, toRef} from 'vue';
 import {computedAsync} from '@vueuse/core';
+import CredentialSelect from './CredentialSelect.vue';
 import {CredentialSwitch} from '@bedrock/vue-vc';
+import {toRef} from 'vue';
 
 export default {
   name: 'CredentialsList',
   components: {
+    CredentialSelect,
     CredentialSwitch,
   },
   props: {
@@ -58,10 +58,10 @@ export default {
       return createCompactBundledCredentials({credentials: credentials.value});
     }, []);
     return {
-      selected: reactive(props.credentials.map(vc => vc.id)),
+      selectedCredentials: new Set(props.credentials.map(vc => vc.id)),
       filteredCredentials
     };
-  }
+  },
 };
 
 // FIXME: refactor and use config

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -5,7 +5,10 @@
       :key="index"
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
-      <credential-select>
+      <credential-select
+        :id="credential.id"
+        :selections="selectedCredentials"
+        @selectVc="handleSelect">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
@@ -22,7 +25,7 @@
 import {computedAsync} from '@vueuse/core';
 import CredentialSelect from './CredentialSelect.vue';
 import {CredentialSwitch} from '@bedrock/vue-vc';
-import {toRef} from 'vue';
+import {ref, toRef} from 'vue';
 
 export default {
   name: 'CredentialsList',
@@ -58,10 +61,16 @@ export default {
       return createCompactBundledCredentials({credentials: credentials.value});
     }, []);
     return {
-      selectedCredentials: new Set(props.credentials.map(vc => vc.id)),
+      selectedCredentials: ref(props.credentials.map(vc => vc.id)),
       filteredCredentials
     };
   },
+  methods: {
+    handleSelect(action) {
+      console.log('select action', action);
+      console.log('selectedCredentials', this.selectedCredentials);
+    }
+  }
 };
 
 // FIXME: refactor and use config

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -5,12 +5,14 @@
       :key="index"
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
-      <credential-select :id="credential.id">
+      <slot
+        name="credential-switch"
+        :credential="credential">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
           :credential="credential" />
-      </credential-select>
+      </slot>
     </div>
   </div>
 </template>
@@ -20,14 +22,12 @@
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computedAsync} from '@vueuse/core';
-import CredentialSelect from './CredentialSelect.vue';
 import {CredentialSwitch} from '@bedrock/vue-vc';
 import {toRef} from 'vue';
 
 export default {
   name: 'CredentialsList',
   components: {
-    CredentialSelect,
     CredentialSwitch,
   },
   props: {

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -6,8 +6,8 @@
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
       <q-checkbox
-        v-model="filteredCredentials"
-        val="credential">
+        v-model="selected"
+        val="credential.id">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
@@ -21,9 +21,9 @@
 /*!
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
+import {reactive, toRef} from 'vue';
 import {computedAsync} from '@vueuse/core';
 import {CredentialSwitch} from '@bedrock/vue-vc';
-import {toRef} from 'vue';
 
 export default {
   name: 'CredentialsList',
@@ -58,6 +58,7 @@ export default {
       return createCompactBundledCredentials({credentials: credentials.value});
     }, []);
     return {
+      selected: reactive(props.credentials.map(vc => vc.id)),
       filteredCredentials
     };
   }

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -8,7 +8,7 @@
       <credential-select
         :id="credential.id"
         :selections="selectedCredentials"
-        @update-selections="handleSelect">
+        @select-credentials="handleSelect">
         <credential-switch
           class="q-ma-xs col"
           :expandable="true"
@@ -56,7 +56,7 @@ export default {
       required: true
     }
   },
-  emits: ['update-selections'],
+  emits: ['select-credentials'],
   setup(props) {
     const credentials = toRef(props, 'credentials');
     const store = toRef(props, 'store');
@@ -72,7 +72,7 @@ export default {
   },
   methods: {
     handleSelect({selections}) {
-      this.$emit('update-selections', {selections});
+      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -5,10 +5,14 @@
       :key="index"
       style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
-      <credential-switch
-        class="q-ma-xs col"
-        :expandable="true"
-        :credential="credential" />
+      <q-checkbox
+        v-model="filteredCredentials"
+        val="credential">
+        <credential-switch
+          class="q-ma-xs col"
+          :expandable="true"
+          :credential="credential" />
+      </q-checkbox>
     </div>
   </div>
 </template>

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <q-checkbox
     :val="id"
-    :model-value="selectedCredentials.value"
+    :model-value="selectedCredentials"
     @click="toggleSelect(id)">
     <slot />
   </q-checkbox>
@@ -12,22 +12,27 @@ import {toRaw} from 'vue';
 
 export default {
   name: 'CredentialSelect',
-  inject: ['selectedCredentials', 'selectCredential'],
   props: {
+    selectedCredentials: {
+      type: Array,
+      default: () => []
+    },
     id: {
       required: true,
       type: String
     }
   },
+  emit: ['select-credentials'],
   methods: {
     toggleSelect(id) {
-      const selections = new Set(toRaw(this.selectedCredentials.value));
+      const selections = new Set(toRaw(this.selectedCredentials));
       if(selections.has(id)) {
         selections.delete(id);
-        return this.selectCredential({selections});
+        this.$emit('select-credentials', {selections});
+        return;
       }
       selections.add(id);
-      this.selectCredential({selections});
+      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -1,10 +1,17 @@
 <template>
-  <q-checkbox
-    :val="id"
-    :model-value="selectedCredentials"
-    @click="toggleSelect(id)">
-    <slot />
-  </q-checkbox>
+  <div style="display: flex; flex-direction: row;">
+    <!-- FIXME: mh:85px is based on height of the cred title + desc. section -->
+    <div style="align-items: center; display: flex; max-height: 85px;">
+      <q-checkbox
+        :val="id"
+        :model-value="selectedCredentials"
+        @click="toggleSelect(id)">
+      </q-checkbox>
+    </div>
+    <div>
+      <slot />
+    </div>
+  </div>
 </template>
 
 <script>

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -22,6 +22,7 @@ export default {
       type: String
     }
   },
+  emits: ['update-selections'],
   methods: {
     toggleSelect(id) {
       const selections = new Set(toRaw(this.selections));

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -22,17 +22,17 @@ export default {
       type: String
     }
   },
-  emits: ['update-selections'],
+  emits: ['select-credentials'],
   methods: {
     toggleSelect(id) {
       const selections = new Set(toRaw(this.selections));
       if(selections.has(id)) {
         selections.delete(id);
-        this.$emit('update-selections', {selections});
+        this.$emit('select-credentials', {selections});
         return;
       }
       selections.add(id);
-      this.$emit('update-selections', {selections});
+      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -1,0 +1,25 @@
+<template>
+  <q-checkbox
+    val="true"
+    @click="toggleSelect(id)">
+    <slot />
+  </q-checkbox>
+</template>
+
+<script>
+export default {
+  name: 'CredentialSelect',
+  methods: {
+    toggleSelect(id) {
+      if(this.selected.has(id)) {
+        this.selected.delete(id);
+        return;
+      }
+      this.selected.add(id);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -26,10 +26,12 @@ export default {
     toggleSelect(id) {
       const selections = new Set(toRaw(this.selections));
       if(selections.has(id)) {
-        this.$emit('selectVc', {remove: id});
+        selections.delete(id);
+        this.$emit('update-selections', {selections});
         return;
       }
-      this.$emit('selectVc', {select: id});
+      selections.add(id);
+      this.$emit('update-selections', {selections});
     }
   }
 };

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -24,6 +24,11 @@ export default {
   },
   emit: ['select-credentials'],
   methods: {
+    /**
+     * Takes in an id and emits a set of selected credentials.
+     *
+     * @param {string} id - A credential id.
+    */
     toggleSelect(id) {
       const selections = new Set(toRaw(this.selectedCredentials));
       if(selections.has(id)) {

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -1,21 +1,35 @@
 <template>
   <q-checkbox
-    val="true"
+    :val="id"
+    :model-value="selections"
     @click="toggleSelect(id)">
     <slot />
   </q-checkbox>
 </template>
 
 <script>
+import {toRaw} from 'vue';
+
 export default {
   name: 'CredentialSelect',
+  props: {
+    selections: {
+      required: true,
+      type: Array
+    },
+    id: {
+      required: true,
+      type: String
+    }
+  },
   methods: {
     toggleSelect(id) {
-      if(this.selected.has(id)) {
-        this.selected.delete(id);
+      const selections = new Set(toRaw(this.selections));
+      if(selections.has(id)) {
+        this.$emit('selectVc', {remove: id});
         return;
       }
-      this.selected.add(id);
+      this.$emit('selectVc', {select: id});
     }
   }
 };

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <q-checkbox
     :val="id"
-    :model-value="selections"
+    :model-value="selectedCredentials.value"
     @click="toggleSelect(id)">
     <slot />
   </q-checkbox>
@@ -12,27 +12,22 @@ import {toRaw} from 'vue';
 
 export default {
   name: 'CredentialSelect',
+  inject: ['selectedCredentials', 'selectCredential'],
   props: {
-    selections: {
-      required: true,
-      type: Array
-    },
     id: {
       required: true,
       type: String
     }
   },
-  emits: ['select-credentials'],
   methods: {
     toggleSelect(id) {
-      const selections = new Set(toRaw(this.selections));
+      const selections = new Set(toRaw(this.selectedCredentials.value));
       if(selections.has(id)) {
         selections.delete(id);
-        this.$emit('select-credentials', {selections});
-        return;
+        return this.selectCredential({selections});
       }
       selections.add(id);
-      this.$emit('select-credentials', {selections});
+      this.selectCredential({selections});
     }
   }
 };

--- a/components/Credentials.vue
+++ b/components/Credentials.vue
@@ -88,7 +88,6 @@ export default {
   setup(props, {emit}) {
     const credentials = toRef(props, 'credentials');
     const search = ref('');
-
     const filteredCredentials = computed(() => {
       emit('filtered-credentials-loading', true);
       const filteredCredentials = credentials.value.filter(({credential}) => {
@@ -101,7 +100,6 @@ export default {
       emit('filtered-credentials-loading', false);
       return filteredCredentials;
     });
-
     const noResults = computed(() => filteredCredentials.value.length === 0);
 
     const emitExtendable = createEmitExtendable();

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -1,9 +1,15 @@
 <template>
   <div v-if="compact">
-    <credential-compact-bundle
+    <slot
+      name="compact-credentials"
       :credentials="credentials"
       :schema-map="schemaMap"
-      :store="store" />
+      :store="store">
+      <credential-compact-bundle
+        :credentials="credentials"
+        :schema-map="schemaMap"
+        :store="store" />
+    </slot>
   </div>
   <div v-else>
     <div

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -5,7 +5,7 @@
       :schema-map="schemaMap"
       :store="store"
       :selected-credentials="selectedCredentials"
-      @update-selections="handleSelect" />
+      @select-credentials="handleSelect" />
   </div>
   <div v-else>
     <div
@@ -124,7 +124,7 @@ export default {
       required: false
     }
   },
-  emits: ['delete-credential'],
+  emits: ['delete-credential', 'select-credentials'],
   data() {
     return {
       schemaMap: {},
@@ -163,7 +163,10 @@ export default {
         'delete-credential', {profileId, credentialId});
     },
     handleSelect({selections}) {
+      // set the view logic
       this.selectedCredentials = [...selections];
+      // pass up to share
+      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -8,7 +8,25 @@
       <credential-compact-bundle
         :credentials="credentials"
         :schema-map="schemaMap"
-        :store="store" />
+        :store="store">
+        <template #credential-switch="switchProps">
+          <credential-select
+            v-if="allowSelection"
+            :id="switchProps.credential.id"
+            :selected-credentials="selectedCredentials"
+            @select-credentials="relaySelection">
+            <credential-switch
+              class="q-ma-xs col"
+              :expandable="true"
+              :credential="switchProps.credential" />
+          </credential-select>
+          <credential-switch
+            v-else
+            class="q-ma-xs col"
+            :expandable="true"
+            :credential="switchProps.credential" />
+        </template>
+      </credential-compact-bundle>
     </slot>
     <q-toggle
       v-model="allowSelection"
@@ -75,12 +93,16 @@
  */
 import CredentialCardBundle from './CredentialCardBundle.vue';
 import CredentialCompactBundle from './CredentialCompactBundle.vue';
+import CredentialSelect from './CredentialSelect.vue';
+import {CredentialSwitch} from '@bedrock/vue-vc';
 
 export default {
   name: 'CredentialsList',
   components: {
     CredentialCardBundle,
-    CredentialCompactBundle
+    CredentialCompactBundle,
+    CredentialSelect,
+    CredentialSwitch
   },
   props: {
     credentials: {
@@ -134,6 +156,10 @@ export default {
       default: false,
       type: Boolean,
       required: false
+    },
+    selectedCredentials: {
+      type: Array,
+      default: () => []
     }
   },
   emits: ['delete-credential', 'select-credentials'],

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -146,6 +146,10 @@ export default {
         !this.loading && this.search.length === 0;
     }
   },
+  created() {
+    // all VCs are selected by default
+    this.selectedCredentials = this.credentialsList.map(vc => vc.id);
+  },
   methods: {
     // FIXME: this should be emitting an event; it should not require
     // knowledge of how the routes are setup -- the top-level page this

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -10,8 +10,8 @@
         :schema-map="schemaMap"
         :store="store">
         <template #credential-switch="switchProps">
-          <credential-select
-            v-if="allowSelection"
+          <component
+            :is="selectableComponent"
             :id="switchProps.credential.id"
             :selected-credentials="selectedCredentials"
             @select-credentials="relaySelection">
@@ -19,12 +19,7 @@
               class="q-ma-xs col"
               :expandable="true"
               :credential="switchProps.credential" />
-          </credential-select>
-          <credential-switch
-            v-else
-            class="q-ma-xs col"
-            :expandable="true"
-            :credential="switchProps.credential" />
+          </component>
         </template>
       </credential-compact-bundle>
     </slot>
@@ -66,13 +61,19 @@
             v-for="credentialRecord in credentialsList"
             :key="credentialRecord.credential.id ?? credentialRecord.meta.id"
             class="row">
-            <credential-card-bundle
-              style="max-width: 300px;"
-              :credential-record="credentialRecord"
-              :schema-map="schemaMap"
-              :profile="profile"
-              :profile-options="profileOptions"
-              @delete="$event.waitUntil(deleteCredential($event))" />
+            <component
+              :is="selectableComponent"
+              :id="switchProps.credential.id"
+              :selected-credentials="selectedCredentials"
+              @select-credentials="relaySelection">
+              <credential-card-bundle
+                style="max-width: 300px;"
+                :credential-record="credentialRecord"
+                :schema-map="schemaMap"
+                :profile="profile"
+                :profile-options="profileOptions"
+                @delete="$event.waitUntil(deleteCredential($event))" />
+            </component>
           </div>
         </div>
       </div>
@@ -183,6 +184,12 @@ export default {
     showNoCredentials() {
       return !this.credentials?.length > 0 &&
         !this.loading && this.search.length === 0;
+    },
+    selectableComponent() {
+      if(this.allowSelection) {
+        return CredentialSelect;
+      }
+      return 'span';
     }
   },
   methods: {

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -3,7 +3,9 @@
     <credential-compact-bundle
       :credentials="credentials"
       :schema-map="schemaMap"
-      :store="store" />
+      :store="store"
+      :selected-credentials="selectedCredentials"
+      @update-selections="handleSelect" />
   </div>
   <div v-else>
     <div
@@ -125,7 +127,8 @@ export default {
   emits: ['delete-credential'],
   data() {
     return {
-      schemaMap: {}
+      schemaMap: {},
+      selectedCredentials: []
     };
   },
   computed: {
@@ -154,6 +157,9 @@ export default {
       // pass event up component chain
       return this.$emitExtendable(
         'delete-credential', {profileId, credentialId});
+    },
+    handleSelect({selections}) {
+      this.selectedCredentials = [...selections];
     }
   }
 };

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -10,6 +10,9 @@
         :schema-map="schemaMap"
         :store="store" />
     </slot>
+    <q-toggle
+      v-model="allowSelection"
+      label="Manual Selection" />
   </div>
   <div v-else>
     <div
@@ -126,12 +129,19 @@ export default {
       default: '',
       type: String,
       required: false
+    },
+    manualCredentialSelection: {
+      default: false,
+      type: Boolean,
+      required: false
     }
   },
-  emits: ['delete-credential'],
+  emits: ['delete-credential', 'select-credentials'],
   data() {
     return {
       schemaMap: {},
+      // init credentialSelection to prop
+      allowSelection: this.manualCredentialSelection
     };
   },
   computed: {
@@ -160,6 +170,9 @@ export default {
       // pass event up component chain
       return this.$emitExtendable(
         'delete-credential', {profileId, credentialId});
+    },
+    relaySelection({selections}) {
+      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -1,28 +1,22 @@
 <template>
   <div v-if="compact">
-    <slot
-      name="compact-credentials"
+    <credential-compact-bundle
       :credentials="credentials"
       :schema-map="schemaMap"
       :store="store">
-      <credential-compact-bundle
-        :credentials="credentials"
-        :schema-map="schemaMap"
-        :store="store">
-        <template #credential-switch="switchProps">
-          <component
-            :is="selectableComponent"
-            :id="switchProps.credential.id"
-            :selected-credentials="selectedCredentials"
-            @select-credentials="relaySelection">
-            <credential-switch
-              class="q-ma-xs col"
-              :expandable="true"
-              :credential="switchProps.credential" />
-          </component>
-        </template>
-      </credential-compact-bundle>
-    </slot>
+      <template #credential-switch="switchProps">
+        <component
+          :is="selectableComponent"
+          :id="switchProps.credential.id"
+          :selected-credentials="selectedCredentials"
+          @select-credentials="relaySelection">
+          <credential-switch
+            class="q-ma-xs col"
+            :expandable="true"
+            :credential="switchProps.credential" />
+        </component>
+      </template>
+    </credential-compact-bundle>
     <q-toggle
       v-model="allowSelection"
       label="Manual Selection" />
@@ -63,7 +57,7 @@
             class="row">
             <component
               :is="selectableComponent"
-              :id="switchProps.credential.id"
+              :id="credentialRecord.id"
               :selected-credentials="selectedCredentials"
               @select-credentials="relaySelection">
               <credential-card-bundle
@@ -75,6 +69,9 @@
                 @delete="$event.waitUntil(deleteCredential($event))" />
             </component>
           </div>
+          <q-toggle
+            v-model="allowSelection"
+            label="Manual Selection" />
         </div>
       </div>
       <q-btn

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -189,6 +189,22 @@ export default {
       return 'span';
     }
   },
+  watch: {
+    allowSelection(newAllow, oldAllow) {
+      // if the new value is the old value
+      // don't retrigger
+      if(newAllow === oldAllow) {
+        return;
+      }
+      // if they are turning off manual selection then select all VCs again
+      if(newAllow === false) {
+        this.$emit(
+          'select-credentials',
+          {selections: this.credentials.map(vc => vc.id)}
+        );
+      }
+    }
+  },
   methods: {
     // FIXME: this should be emitting an event; it should not require
     // knowledge of how the routes are setup -- the top-level page this

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -3,9 +3,7 @@
     <credential-compact-bundle
       :credentials="credentials"
       :schema-map="schemaMap"
-      :store="store"
-      :selected-credentials="selectedCredentials"
-      @select-credentials="handleSelect" />
+      :store="store" />
   </div>
   <div v-else>
     <div
@@ -124,11 +122,10 @@ export default {
       required: false
     }
   },
-  emits: ['delete-credential', 'select-credentials'],
+  emits: ['delete-credential'],
   data() {
     return {
       schemaMap: {},
-      selectedCredentials: []
     };
   },
   computed: {
@@ -146,10 +143,6 @@ export default {
         !this.loading && this.search.length === 0;
     }
   },
-  created() {
-    // all VCs are selected by default
-    this.selectedCredentials = this.credentialsList.map(vc => vc.id);
-  },
   methods: {
     // FIXME: this should be emitting an event; it should not require
     // knowledge of how the routes are setup -- the top-level page this
@@ -161,12 +154,6 @@ export default {
       // pass event up component chain
       return this.$emitExtendable(
         'delete-credential', {profileId, credentialId});
-    },
-    handleSelect({selections}) {
-      // set the view logic
-      this.selectedCredentials = [...selections];
-      // pass up to share
-      this.$emit('select-credentials', {selections});
     }
   }
 };

--- a/components/CredentialsList.vue
+++ b/components/CredentialsList.vue
@@ -18,6 +18,7 @@
       </template>
     </credential-compact-bundle>
     <q-toggle
+      v-if="selectable"
       v-model="allowSelection"
       label="Manual Selection" />
   </div>
@@ -57,7 +58,7 @@
             class="row">
             <component
               :is="selectableComponent"
-              :id="credentialRecord.id"
+              :id="credentialRecord.credential.id ?? credentialRecord.meta.id"
               :selected-credentials="selectedCredentials"
               @select-credentials="relaySelection">
               <credential-card-bundle
@@ -70,6 +71,7 @@
             </component>
           </div>
           <q-toggle
+            v-if="selectable"
             v-model="allowSelection"
             label="Manual Selection" />
         </div>
@@ -150,7 +152,7 @@ export default {
       type: String,
       required: false
     },
-    manualCredentialSelection: {
+    selectable: {
       default: false,
       type: Boolean,
       required: false
@@ -165,7 +167,7 @@ export default {
     return {
       schemaMap: {},
       // init credentialSelection to prop
-      allowSelection: this.manualCredentialSelection
+      allowSelection: this.selectable
     };
   },
   computed: {
@@ -183,7 +185,8 @@ export default {
         !this.loading && this.search.length === 0;
     },
     selectableComponent() {
-      if(this.allowSelection) {
+      const selectable = this.selectable && this.allowSelection;
+      if(selectable) {
         return CredentialSelect;
       }
       return 'span';

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -94,6 +94,13 @@ export default {
     ShareHeader,
     ShareReview
   },
+  provide() {
+    return {
+      selectedCredentials: computed(() => this.selectedCredentials),
+      selectCredential: ({selections}) =>
+        this.selectedCredentials = [...selections]
+    };
+  },
   props: {
     query: {
       type: [Object, Array],
@@ -184,6 +191,7 @@ export default {
     });
 
     const displayableCredentials = ref([]);
+    const selectedCredentials = ref([]);
 
     const verifiableCredentialUpdating = ref(true);
     const verifiableCredential = computedAsync(async () => {
@@ -210,8 +218,10 @@ export default {
 
       const records = await getRecords(
         {query: credentialQuery.value, profileId});
+      const displayContainers = await createContainers({records});
       // creates container credentials for display only
-      displayableCredentials.value = await createContainers({records});
+      displayableCredentials.value = displayContainers;
+      selectedCredentials.value = displayContainers.map(vc => vc.id);
       const credentials = records.map(r => r.content);
       return credentials;
     }, [], verifiableCredentialUpdating);
@@ -227,6 +237,7 @@ export default {
     return {
       credentialQuery,
       displayableCredentials,
+      selectedCredentials,
       icon,
       loading,
       profiles,

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -39,6 +39,7 @@
           <template #credentials-display="displayProps">
             <credentials-list
               :compact="true"
+              :selectable="true"
               :selected-credentials="selectedCredentials"
               :credentials="displayProps.credentials"
               @select-credentials="selectCredentials" />

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -39,7 +39,26 @@
           <template #credentials-display="displayProps">
             <credentials-list
               :compact="true"
-              :credentials="displayProps.credentials" />
+              :credentials="displayProps.credentials">
+              <template #compact-credentials="compactProps">
+                <credential-compact-bundle
+                  :credentials="compactProps.credentials"
+                  :schema-map="compactProps.schemaMap"
+                  :store="compactProps.store">
+                  <template #credential-switch="switchProps">
+                    <credential-select
+                      :id="switchProps.credential.id"
+                      :selected-credentials="selectedCredentials"
+                      @select-credentials="selectCredentials">
+                      <credential-switch
+                        class="q-ma-xs col"
+                        :expandable="true"
+                        :credential="switchProps.credential" />
+                    </credential-select>
+                  </template>
+                </credential-compact-bundle>
+              </template>
+            </credentials-list>
           </template>
         </share-review>
       </div>
@@ -79,7 +98,10 @@ import {
 } from '@bedrock/web-wallet';
 import {computed, ref, toRaw, toRef} from 'vue';
 import {computedAsync} from '@vueuse/core';
+import CredentialCompactBundle from './CredentialCompactBundle.vue';
+import CredentialSelect from './CredentialSelect.vue';
 import CredentialsList from './CredentialsList.vue';
+import {CredentialSwitch} from '@bedrock/vue-vc';
 import ProfileChooser from './ProfileChooser.vue';
 import ShareHeader from './ShareHeader.vue';
 import ShareReview from './ShareReview.vue';
@@ -97,17 +119,13 @@ const manifestClient = new WebAppManifestClient();
 export default {
   name: 'Share',
   components: {
+    CredentialCompactBundle,
     CredentialsList,
+    CredentialSelect,
+    CredentialSwitch,
     ProfileChooser,
     ShareHeader,
     ShareReview
-  },
-  provide() {
-    return {
-      selectedCredentials: computed(() => this.selectedCredentials),
-      selectCredential: ({selections}) =>
-        this.selectedCredentials = [...selections]
-    };
   },
   props: {
     query: {
@@ -319,6 +337,9 @@ export default {
       const profileId = this.selectedProfile.id;
       return [].concat(...await Promise.all(this.capabilityQuery.map(
         async request => createCapabilities({profileId, request}))));
+    },
+    selectCredentials({selections}) {
+      this.selectedCredentials = [...selections];
     },
     async share() {
       this.sharing = true;

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -39,26 +39,9 @@
           <template #credentials-display="displayProps">
             <credentials-list
               :compact="true"
-              :credentials="displayProps.credentials">
-              <template #compact-credentials="compactProps">
-                <credential-compact-bundle
-                  :credentials="compactProps.credentials"
-                  :schema-map="compactProps.schemaMap"
-                  :store="compactProps.store">
-                  <template #credential-switch="switchProps">
-                    <credential-select
-                      :id="switchProps.credential.id"
-                      :selected-credentials="selectedCredentials"
-                      @select-credentials="selectCredentials">
-                      <credential-switch
-                        class="q-ma-xs col"
-                        :expandable="true"
-                        :credential="switchProps.credential" />
-                    </credential-select>
-                  </template>
-                </credential-compact-bundle>
-              </template>
-            </credentials-list>
+              :selected-credentials="selectedCredentials"
+              :credentials="displayProps.credentials"
+              @select-credentials="selectCredentials" />
           </template>
         </share-review>
       </div>
@@ -98,10 +81,7 @@ import {
 } from '@bedrock/web-wallet';
 import {computed, ref, toRaw, toRef} from 'vue';
 import {computedAsync} from '@vueuse/core';
-import CredentialCompactBundle from './CredentialCompactBundle.vue';
-import CredentialSelect from './CredentialSelect.vue';
 import CredentialsList from './CredentialsList.vue';
-import {CredentialSwitch} from '@bedrock/vue-vc';
 import ProfileChooser from './ProfileChooser.vue';
 import ShareHeader from './ShareHeader.vue';
 import ShareReview from './ShareReview.vue';
@@ -119,10 +99,7 @@ const manifestClient = new WebAppManifestClient();
 export default {
   name: 'Share',
   components: {
-    CredentialCompactBundle,
     CredentialsList,
-    CredentialSelect,
-    CredentialSwitch,
     ProfileChooser,
     ShareHeader,
     ShareReview

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -352,7 +352,11 @@ export default {
           holder: this.selectedProfile.id
         };
         if(verifiableCredential.length > 0) {
-          presentation.verifiableCredential = toRaw(verifiableCredential);
+          const vcs = toRaw(verifiableCredential);
+          const selections = toRaw(this.selectedCredentials);
+          // only send the VCs selected
+          presentation.verifiableCredential = vcs.filter(
+            vc => selections.includes(vc.id));
         }
         const capabilities = await this.generateCapabilities();
         // Presentations with out capabilities will result

--- a/components/Share.vue
+++ b/components/Share.vue
@@ -35,7 +35,13 @@
           :request-origin="requestOrigin"
           :type="query.type"
           :style="$q.screen.lt.sm ?
-            'border-bottom: 1px solid rgba(157, 157, 157, 0.75)' : ''" />
+            'border-bottom: 1px solid rgba(157, 157, 157, 0.75)' : ''">
+          <template #credentials-display="displayProps">
+            <credentials-list
+              :compact="true"
+              :credentials="displayProps.credentials" />
+          </template>
+        </share-review>
       </div>
       <div
         class="self-end row justify-between q-py-md q-px-lg"
@@ -73,6 +79,7 @@ import {
 } from '@bedrock/web-wallet';
 import {computed, ref, toRaw, toRef} from 'vue';
 import {computedAsync} from '@vueuse/core';
+import CredentialsList from './CredentialsList.vue';
 import ProfileChooser from './ProfileChooser.vue';
 import ShareHeader from './ShareHeader.vue';
 import ShareReview from './ShareReview.vue';
@@ -90,6 +97,7 @@ const manifestClient = new WebAppManifestClient();
 export default {
   name: 'Share',
   components: {
+    CredentialsList,
     ProfileChooser,
     ShareHeader,
     ShareReview

--- a/components/ShareReview.vue
+++ b/components/ShareReview.vue
@@ -6,8 +6,12 @@
       </div>
       <q-separator class="s-separator" />
       <div>
-        <capabilities-list
-          :capabilities="capabilities" />
+        <slot
+          name="capabilities-display"
+          :capabilities="capabilities">
+          <capabilities-list
+            :capabilities="capabilities" />
+        </slot>
       </div>
     </div>
     <div v-if="credentials.length > 0">

--- a/components/ShareReview.vue
+++ b/components/ShareReview.vue
@@ -16,9 +16,13 @@
       </div>
       <q-separator class="s-separator" />
       <div>
-        <credentials-list
-          :compact="true"
-          :credentials="credentials" />
+        <slot
+          name="credentials-display"
+          :credentials="credentials">
+          <credentials-list
+            :compact="true"
+            :credentials="credentials" />
+        </slot>
       </div>
     </div>
     <div v-else>


### PR DESCRIPTION
3 different attempts were tried before settling on the one in this PR.

1. Prop Drilling and Emit Relaying.
    - This resulted in multiple 4+ prop drills and relays
2. Provide / Inject
    - This worked really well actually, the Share.vue provided a selectedCredentials via a computed property and a function to mutate selected credentials.
    - I discussed this with Dave Longely and he was not sure if we wanted to use this pattern.
    - Provide/Inject is listed in the vue docs as a potential solution to long emit chains.
3. Slot/ Templates/ Emit
    - This is the one used by the PR
    - This is actually really useful for both prop drilling and emits
    - Take a look at [ShareReview.vue](https://github.com/digitalbazaar/bedrock-vue-wallet/blob/main/components/ShareReview.vue) for instance, it just takes props to pass them to other components inside of it without modification.
    - What this means is that we could remove credentials and capabilities from ShareReview and replace them with templates removing prop drilling for credentials & emit relays by 1 while also making ShareReview able to take multiple different components in the future.
    - In general if you're just passing props to pass props you should probably be using a slot and a template instead.
    - A good example of a case where props are needed is CredentialsList which wraps those props in a show more functionality before passing them to CredentialSwitch.

Heirarchy


@bedrock/vue-wallet
  - Share.vue <-- container that emits an event with the VerifiablePresentation to share
    - ProfileChooser.vue
    - ShareHeader.vue
    - ShareReview.vue <- primarily a style component
      - CapabilitiesList.vue
      - CredentialsList.vue <-- add auto/manual here ([QToggle](https://quasar.dev/vue-components/toggle))
        - CredentialCardBundle.vue 
          - CredentialSwitch <- this is now wrapped in a CredentialSelect component
        - CredentialCompactBundle.vue <- this is now wrapped in a CredentialSelect component
          - CredentialSwitch 


Screenshot:
<img width="686" alt="Screen Shot 2023-03-06 at 11 51 25 AM" src="https://user-images.githubusercontent.com/278280/223190956-f5451922-2615-45c9-8a43-69312d6c4318.png">
