### PR TITLE
Use account id to restrict AllowWallet notifications.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,14 @@
 import {installHandler} from 'web-credential-handler';
 import {Notify} from 'quasar';
 
-export function notifyAllowWallet() {
+const notifiedAccounts = new Map();
+
+export function notifyAllowWallet(account) {
+  // if already notified ignore
+  if(notifiedAccounts.get(account)) {
+    return;
+  }
+  // if inside a WebView ignore
   if(isWebView({userAgent: navigator?.userAgent})) {
     return;
   }
@@ -22,6 +29,8 @@ export function notifyAllowWallet() {
         try {
           // install credential handler
           await installHandler({url: '/credential-handler'});
+          // don't show the notification to the same account again
+          notifiedAccounts.set(account, true);
         } catch(e) {
           // eslint-disable-line no-console
           console.error('CHAPI register error:', e);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,7 +8,7 @@ const notifiedAccounts = new Map();
 
 export function notifyAllowWallet({account, preventRenotify = false}) {
   // if already notified ignore
-  if(notifiedAccounts.get(account)) {
+  if(preventRenotify && notifiedAccounts.get(account)) {
     return;
   }
   // if inside a WebView ignore

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -46,7 +46,11 @@ export function notifyAllowWallet(account) {
       }
     }, {
       icon: 'fas fa-times',
-      color: 'white'
+      color: 'white',
+      handler() {
+        // if the user dismisses the notification don't show it again
+        notifiedAccounts.set(account, true);
+      }
     }]
   });
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,7 @@ import {Notify} from 'quasar';
 
 const notifiedAccounts = new Map();
 
-export function notifyAllowWallet(account) {
+export function notifyAllowWallet({account, preventRenotify = false}) {
   // if already notified ignore
   if(notifiedAccounts.get(account)) {
     return;

--- a/lib/router.js
+++ b/lib/router.js
@@ -3,7 +3,6 @@
  */
 import * as brQuasar from '@bedrock/quasar';
 import {config} from '@bedrock/web';
-import {notifyAllowWallet} from './helpers.js';
 import Quasar from 'quasar';
 import {rootData} from './rootData.js';
 import {session} from '@bedrock/web-session';
@@ -38,11 +37,7 @@ const FEATURES = new Map([
     routes: [{
       name: 'home',
       path: routeConfig.path,
-      beforeEnter: [
-        requireLogin,
-        () => notifyAllowWallet(
-          {account: session?.data?.account, preventRenotify: true})
-      ],
+      beforeEnter: [requireLogin],
       component: () => import(
         /* webpackChunkName: "bedrock-vue-wallet-home" */
         '../routes/HomePage.vue'),

--- a/lib/router.js
+++ b/lib/router.js
@@ -38,7 +38,10 @@ const FEATURES = new Map([
     routes: [{
       name: 'home',
       path: routeConfig.path,
-      beforeEnter: [requireLogin, notifyAllowWallet],
+      beforeEnter: [
+        requireLogin,
+        () => notifyAllowWallet(session?.data?.account)
+      ],
       component: () => import(
         /* webpackChunkName: "bedrock-vue-wallet-home" */
         '../routes/HomePage.vue'),

--- a/lib/router.js
+++ b/lib/router.js
@@ -40,7 +40,8 @@ const FEATURES = new Map([
       path: routeConfig.path,
       beforeEnter: [
         requireLogin,
-        () => notifyAllowWallet(session?.data?.account)
+        () => notifyAllowWallet(
+          {account: session?.data?.account, preventRenotify: true})
       ],
       component: () => import(
         /* webpackChunkName: "bedrock-vue-wallet-home" */

--- a/routes/HomePage.vue
+++ b/routes/HomePage.vue
@@ -20,6 +20,7 @@ import {
 import {computed, ref, toRef, watch} from 'vue';
 import {computedAsync} from '@vueuse/core';
 import Credentials from '../components/Credentials.vue';
+import {notifyAllowWallet} from '../lib/helpers.js';
 
 export default {
   name: 'HomePage',
@@ -34,7 +35,6 @@ export default {
   },
   setup(props) {
     const accountId = toRef(props, 'account');
-
     const errorText = ref('');
 
     const loadingProfiles = ref(true);
@@ -125,6 +125,7 @@ export default {
       loadingProfiles.value);
 
     return {
+      accountId,
       credentials,
       deleteCredential,
       errorText,
@@ -134,6 +135,9 @@ export default {
       loadingFilteredCredentials,
       profiles
     };
+  },
+  mounted() {
+    notifyAllowWallet({account: this.accountId, preventRenotify: true});
   }
 };
 </script>

--- a/routes/HomePage.vue
+++ b/routes/HomePage.vue
@@ -17,7 +17,7 @@ import {
   getCredentialStore,
   profileManager
 } from '@bedrock/web-wallet';
-import {computed, ref, toRef, watch} from 'vue';
+import {computed, onMounted, ref, toRef, watch} from 'vue';
 import {computedAsync} from '@vueuse/core';
 import Credentials from '../components/Credentials.vue';
 import {notifyAllowWallet} from '../lib/helpers.js';
@@ -123,9 +123,13 @@ export default {
       loadingFilteredCredentials.value ||
       loadingCredentials.value ||
       loadingProfiles.value);
+    // on mount possibly show the wallet authorization notification
+    onMounted(() => notifyAllowWallet({
+      account: accountId.value,
+      preventRenotify: true
+    }));
 
     return {
-      accountId,
       credentials,
       deleteCredential,
       errorText,
@@ -135,9 +139,6 @@ export default {
       loadingFilteredCredentials,
       profiles
     };
-  },
-  mounted() {
-    notifyAllowWallet({account: this.accountId, preventRenotify: true});
   }
 };
 </script>


### PR DESCRIPTION
This adds a cache in the form of a Map that keeps the Allow Wallet notification from showing up multiple times in a session.

Addresses: https://github.com/digitalbazaar/bedrock-vue-wallet/issues/31