### PR TITLE
Use @bedrock/web's config for platform detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 19.1.0 -
 
 ### Added
-- CHAPI notification can be disabled in WebView.
+- A new config option `disableChapi` for disabling chapi.
 
 ## 19.0.0 - 2023-04-dd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 19.1.0 -
+
+### Added
+- CHAPI notification can be disabled in WebView.
+
 ## 19.0.0 - 2023-04-dd
 
 ### Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,9 @@ const cfg = {
       info: '#FFFFFF', // header text
       accent: '#FFFFFF' + '80' // links - 80% opacity
     }
-  }
+  },
+  // CHAPI is on by default
+  disableChapi: false
 };
 
 // expose as `vueWallet` on shared web app config

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2019-2023 Digital Bazaar, Inc. All rights reserved.
  */
+import {config} from '@bedrock/web';
 import {installHandler} from 'web-credential-handler';
 import {Notify} from 'quasar';
 
@@ -12,7 +13,7 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
     return;
   }
   // if inside a WebView ignore
-  if(isWebView({userAgent: navigator?.userAgent})) {
+  if(config.isWebView === true) {
     return;
   }
   return Notify.create({
@@ -53,11 +54,4 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
       }
     }]
   });
-}
-
-export function isWebView() {
-  if(window?.Capacitor?.isNativePlatform) {
-    return window.Capacitor.isNativePlatform();
-  }
-  return false;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,8 +12,7 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
   if(preventRenotify && notifiedAccounts.get(account)) {
     return;
   }
-  // if inside a WebView ignore
-  if(config?.isWebView === true) {
+  if(config?.vueWallet?.disableChapi === true) {
     return;
   }
   return Notify.create({

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -55,22 +55,9 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
   });
 }
 
-export function isWebView({userAgent = ''}) {
-  if(userAgent.includes('WebView')) {
-    return true;
-  }
-  const iosPlatforms = ['iPhone', 'iPod', 'iPad'];
-  if(iosPlatforms.some(p => userAgent.includes(p))) {
-    // if the UA includes Safari it is not a WebView
-    if(!userAgent.includes('Safari')) {
-      return true;
-    }
-  }
-  if(userAgent.includes('Android')) {
-    // if the UA includes wv it is a WebView
-    if(userAgent.includes('; wv')) {
-      return true;
-    }
+export function isWebView() {
+  if(window?.Capacitor?.isNativePlatform) {
+    return window.Capacitor.isNativePlatform();
   }
   return false;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,7 +12,7 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
   if(preventRenotify && notifiedAccounts.get(account)) {
     return;
   }
-  if(config?.vueWallet?.disableChapi === true) {
+  if(config?.vueWallet?.disableChapi) {
     return;
   }
   return Notify.create({

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,7 +13,7 @@ export function notifyAllowWallet({account, preventRenotify = false}) {
     return;
   }
   // if inside a WebView ignore
-  if(config.isWebView === true) {
+  if(config?.isWebView === true) {
     return;
   }
   return Notify.create({

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "peerDependencies": {
     "@bedrock/quasar": "^9.0.0",
     "@bedrock/vue-vc": "^2.0.0",
+    "@bedrock/web": "^3.0.0",
     "@bedrock/web-fontawesome": "^2.0.0",
     "@bedrock/web-wallet": "^11.0.0",
     "@digitalbazaar/vue-extendable-event": "^4.1.0",


### PR DESCRIPTION
This is a draft because we might not want to use a method conditional on using a library to determine if we're in a WebView, but as of Capacitor v3 & v4 `window.Capacitor.isNativePlatform()` returns a boolean telling if you're inside of a Capacitor app which is there for a WebView (you can also get the platform name).

The code determines if you're inside of a Capacitor app by looking for native bridges that Capacitor only installs from the native code itself:

https://github.com/ionic-team/capacitor/blob/5a6971f73a2022d49f68f1898af7f41a85310e3c/core/native-bridge.ts#L21-L29

Possibly addresses: https://github.com/digitalbazaar/bedrock-vue-wallet/issues/35

Docs are here: https://capacitorjs.com/docs/core-apis/web#isnativeplatform

EDIT:

This was revised based off of recent discussion. We're now doing this:

1. `@bedrock/web` is a peer dep.
2. We use `import {config} from `@bedrock/web`;
3. `config` should contain `config.isWebView`
4. If isWebView is true skip the authn credential handler notification
5. isWebView is currently being set by using Capacitor's `isNativePlatform` in a project using this library.
