### PR TITLE
Fix lint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,5 +13,8 @@ module.exports = {
     'digitalbazaar/jsdoc',
     'digitalbazaar/vue'
   ],
+  rules: {
+    'vue/multi-word-component-names': 0
+  },
   ignorePatterns: ['node_modules/']
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # bedrock-vue-wallet ChangeLog
 
-## 19.1.0 -
+## 19.1.1 -
 
 ### Added
 - A new config option `disableChapi` for disabling chapi.
+
+### Fixed
+- RemoveItemModel now emits a value for show.
 
 ## 19.0.0 - 2023-04-dd
 

--- a/components/AccessManagement.vue
+++ b/components/AccessManagement.vue
@@ -62,12 +62,12 @@
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, ref, toRef} from 'vue';
-import {computedAsync} from '@vueuse/core';
-import AddUserModal from './AddUserModal.vue';
-import {BrQTable} from '@bedrock/quasar-components';
-import EditUserModal from './EditUserModal.vue';
 import {format, utils} from 'quasar';
 import {profileManager, users} from '@bedrock/web-wallet';
+import AddUserModal from './AddUserModal.vue';
+import {BrQTable} from '@bedrock/quasar-components';
+import {computedAsync} from '@vueuse/core';
+import EditUserModal from './EditUserModal.vue';
 import RemoveItemModal from './RemoveItemModal.vue';
 import SearchBox from './SearchBox.vue';
 

--- a/components/AddProfileModal.vue
+++ b/components/AddProfileModal.vue
@@ -1,8 +1,8 @@
 <template>
   <br-q-modal
+    v-model="show"
     title="Add Profile"
     accept-label="Create"
-    v-model="show"
     :persistent="persistent"
     :disable-accept-button="disableAcceptButton"
     @accept="$event.waitUntil($emitExtendable('create', {form}))">

--- a/components/AddUserModal.vue
+++ b/components/AddUserModal.vue
@@ -16,6 +16,7 @@
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQModal} from '@bedrock/quasar-components';
+import {computed} from 'vue';
 import UserForm from './UserForm.vue';
 
 export default {

--- a/components/CapabilitiesList.vue
+++ b/components/CapabilitiesList.vue
@@ -34,7 +34,7 @@
 // e.g., `CapabilityDescription.vue` -- and it should be created and moved
 // there rather than be a lib function
 import {capabilities} from '@bedrock/web-wallet';
-const {generateDescription}  = capabilities;
+const {generateDescription} = capabilities;
 
 export default {
   name: 'CapabilitiesList',

--- a/components/CodeInput.vue
+++ b/components/CodeInput.vue
@@ -20,7 +20,7 @@
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, ref, watch} from 'vue';
-import {required, minLength, maxLength} from '@vuelidate/validators';
+import {maxLength, minLength, required} from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
 
 export default {
@@ -48,6 +48,7 @@ export default {
       default: Infinity
     }
   },
+  emits: ['code', 'invalid'],
   setup(props, {emit}) {
     const vuelidate = useVuelidate();
 
@@ -82,7 +83,6 @@ export default {
       vuelidate
     };
   },
-  emits: ['code', 'invalid'],
   validations() {
     return {
       code: {

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -65,9 +65,13 @@ const hiddenCredentialTypes = new Map([
   ['OverAgeTokenCredential', true],
   ['AgeVerificationCredential', true]
 ]);
+
+/*
+// FIXME unused currently
 const bundleCredentialTypes = new Map([
   ['AgeVerificationContainerCredential', true]
 ]);
+*/
 
 // FIXME: refactor and move elsewhere
 async function createCompactBundledCredentials({credentials}) {

--- a/components/Credentials.vue
+++ b/components/Credentials.vue
@@ -46,8 +46,8 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {BrQTitleCard} from '@bedrock/quasar-components';
 import {computed, ref, toRef, watch} from 'vue';
+import {BrQTitleCard} from '@bedrock/quasar-components';
 import {createEmitExtendable} from '@digitalbazaar/vue-extendable-event';
 import CredentialsList from './CredentialsList.vue';
 import SearchBox from './SearchBox.vue';

--- a/components/EditUserModal.vue
+++ b/components/EditUserModal.vue
@@ -17,8 +17,9 @@
 /*!
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {BrQModal} from '@bedrock/quasar-components';
 import {email, required} from '@vuelidate/validators';
+import {BrQModal} from '@bedrock/quasar-components';
+import {computed} from 'vue';
 import UserForm from './UserForm.vue';
 import useVuelidate from '@vuelidate/core';
 

--- a/components/EditUserModal.vue
+++ b/components/EditUserModal.vue
@@ -18,7 +18,7 @@
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQModal} from '@bedrock/quasar-components';
-import {required, email} from '@vuelidate/validators';
+import {email, required} from '@vuelidate/validators';
 import UserForm from './UserForm.vue';
 import useVuelidate from '@vuelidate/core';
 

--- a/components/GeneralSettings.vue
+++ b/components/GeneralSettings.vue
@@ -47,8 +47,8 @@
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, ref} from 'vue';
-import {getPrimaryEmail} from '@bedrock/web-wallet';
 import {email, required} from '@vuelidate/validators';
+import {getPrimaryEmail} from '@bedrock/web-wallet';
 import useVuelidate from '@vuelidate/core';
 
 export default {

--- a/components/GeneralSettings.vue
+++ b/components/GeneralSettings.vue
@@ -48,7 +48,7 @@
  */
 import {computed, ref} from 'vue';
 import {getPrimaryEmail} from '@bedrock/web-wallet';
-import {required, email} from '@vuelidate/validators';
+import {email, required} from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
 
 export default {

--- a/components/Interact.vue
+++ b/components/Interact.vue
@@ -63,12 +63,15 @@
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import QrCode from './QrCode.vue';
-//import {RsvpClient} from 'rsvp-client';
+/*
+FIXME: implement RsvpClient
+import {RsvpClient} from 'rsvp-client';
 
 const payload = {
   ttl: 300000,
   type: 'someType'
 };
+*/
 
 export default {
   name: 'Interact',

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -202,12 +202,12 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
+import {email, required} from '@vuelidate/validators';
 import {BrQTitleCard} from '@bedrock/quasar-components';
 import CodeInput from './CodeInput.vue';
 import {config} from '@bedrock/web';
 import {helpers} from '@bedrock/web-wallet';
 import {LoginController} from '@bedrock/web-authn-token';
-import {email, required} from '@vuelidate/validators';
 import {session} from '@bedrock/web-session';
 import useVuelidate from '@vuelidate/core';
 

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -207,7 +207,7 @@ import CodeInput from './CodeInput.vue';
 import {config} from '@bedrock/web';
 import {helpers} from '@bedrock/web-wallet';
 import {LoginController} from '@bedrock/web-authn-token';
-import {required, email} from '@vuelidate/validators';
+import {email, required} from '@vuelidate/validators';
 import {session} from '@bedrock/web-session';
 import useVuelidate from '@vuelidate/core';
 

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -115,7 +115,8 @@
               You may also click directly on the link sent to your email.
             </p>
             <code-input
-              hint="Please enter the 6 character code sent to your email address."
+              hint="Please enter the 6 character code sent to your email
+                address."
               :min-length="6"
               :max-length="6"
               @code="emailCode = $event.code"

--- a/components/ProfileForm.vue
+++ b/components/ProfileForm.vue
@@ -91,7 +91,7 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, toRef} from 'vue';
-import {required, requiredIf, minLength} from '@vuelidate/validators';
+import {minLength, required, requiredIf} from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
 
 export default {

--- a/components/Profiles.vue
+++ b/components/Profiles.vue
@@ -49,7 +49,7 @@
  */
 import AddProfileModal from './AddProfileModal.vue';
 import {BrQTable} from '@bedrock/quasar-components';
-import {helpers, getPrimaryEmail, profileManager} from '@bedrock/web-wallet';
+import {getPrimaryEmail, helpers, profileManager} from '@bedrock/web-wallet';
 import SearchBox from './SearchBox.vue';
 import {date} from 'quasar';
 

--- a/components/Profiles.vue
+++ b/components/Profiles.vue
@@ -47,11 +47,11 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
+import {getPrimaryEmail, helpers, profileManager} from '@bedrock/web-wallet';
 import AddProfileModal from './AddProfileModal.vue';
 import {BrQTable} from '@bedrock/quasar-components';
-import {getPrimaryEmail, helpers, profileManager} from '@bedrock/web-wallet';
-import SearchBox from './SearchBox.vue';
 import {date} from 'quasar';
+import SearchBox from './SearchBox.vue';
 
 const {createProfile} = helpers;
 const {formatDate} = date;

--- a/components/Register.vue
+++ b/components/Register.vue
@@ -106,11 +106,11 @@
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {AccountService, RegisterController} from '@bedrock/web-account';
+import {email, minLength, required} from '@vuelidate/validators';
 import {BrQTitleCard} from '@bedrock/quasar-components';
 import {config} from '@bedrock/web';
 import {helpers} from '@bedrock/web-wallet';
 import {randomColor} from 'randomcolor';
-import {email, minLength, required} from '@vuelidate/validators';
 import {session} from '@bedrock/web-session';
 import {TokenService} from '@bedrock/web-authn-token';
 import useVuelidate from '@vuelidate/core';

--- a/components/Register.vue
+++ b/components/Register.vue
@@ -110,7 +110,7 @@ import {BrQTitleCard} from '@bedrock/quasar-components';
 import {config} from '@bedrock/web';
 import {helpers} from '@bedrock/web-wallet';
 import {randomColor} from 'randomcolor';
-import {required, email, minLength} from '@vuelidate/validators';
+import {email, minLength, required} from '@vuelidate/validators';
 import {session} from '@bedrock/web-session';
 import {TokenService} from '@bedrock/web-authn-token';
 import useVuelidate from '@vuelidate/core';

--- a/components/RemoveItemModal.vue
+++ b/components/RemoveItemModal.vue
@@ -33,6 +33,7 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQModal} from '@bedrock/quasar-components';
+import {computed} from 'vue';
 import {format} from 'quasar';
 
 export default {

--- a/components/RemoveItemModal.vue
+++ b/components/RemoveItemModal.vue
@@ -69,7 +69,7 @@ export default {
   setup(props, {emit}) {
     const show = computed({
       get: () => props.modelValue,
-      set: emit('update:modelValue', value)
+      set: value => emit('update:modelValue', value)
     });
     return {
       show

--- a/components/StoreCredentials.vue
+++ b/components/StoreCredentials.vue
@@ -64,8 +64,8 @@
  */
 import {computedAsync} from '@vueuse/core';
 import CredentialsList from './CredentialsList.vue';
-import {profileManager} from '@bedrock/web-wallet';
 import ProfileChooser from './ProfileChooser.vue';
+import {profileManager} from '@bedrock/web-wallet';
 import {ref} from 'vue';
 
 export default {

--- a/components/TwoFactorSettings.vue
+++ b/components/TwoFactorSettings.vue
@@ -88,8 +88,8 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {email} from '@vuelidate/validators';
 import {AccountService} from '@bedrock/web-account';
+import {email} from '@vuelidate/validators';
 import {session} from '@bedrock/web-session';
 import {TokenService} from '@bedrock/web-authn-token';
 import useVuelidate from '@vuelidate/core';

--- a/components/UserForm.vue
+++ b/components/UserForm.vue
@@ -73,7 +73,7 @@
 /*!
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {required, email} from '@vuelidate/validators';
+import {email, required} from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
 import {watch} from 'vue';
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "routes/*"
   ],
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint \"**/*.{js,vue}\""
   },
   "dependencies": {
     "@digitalbazaar/web-app-manifest-utils": "^2.0.0",

--- a/routes/ChapiSharePage.vue
+++ b/routes/ChapiSharePage.vue
@@ -60,8 +60,8 @@
  */
 import {cryptoSuites, helpers, presentations} from '@bedrock/web-wallet';
 import Login from '../components/Login.vue';
-import Problem from '../components/Problem.vue';
 import Next from '../components/Next.vue';
+import Problem from '../components/Problem.vue';
 import {receiveCredentialEvent} from 'web-credential-handler';
 import Register from '../components/Register.vue';
 import {session} from '@bedrock/web-session';

--- a/routes/InteractPage.vue
+++ b/routes/InteractPage.vue
@@ -26,8 +26,8 @@
     </div>
     <br-q-modal
       v-if="help"
-      title="Interact Help"
       v-model="help"
+      title="Interact Help"
       bottom-separator
       full-width-buttons
       accept-label="Done"

--- a/routes/InteractPage.vue
+++ b/routes/InteractPage.vue
@@ -62,8 +62,8 @@
 /*!
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import Interact from '../components/Interact.vue';
 import {BrQModal, BrQTitleCard} from '@bedrock/quasar-components';
+import Interact from '../components/Interact.vue';
 
 export default {
   name: 'InteractPage',

--- a/routes/SettingsPage.vue
+++ b/routes/SettingsPage.vue
@@ -117,14 +117,14 @@
 /*!
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import AccessManagement from '../components/AccessManagement.vue';
 import {computed, ref, watch} from 'vue';
+import {useRoute, useRouter} from 'vue-router';
+import AccessManagement from '../components/AccessManagement.vue';
 import GeneralSettings from '../components/GeneralSettings.vue';
 import {profileManager} from '@bedrock/web-wallet';
 import ProfileSettings from '../components/ProfileSettings.vue';
 import SettingsModule from '../components/SettingsModule.vue';
 import TwoFactorSettings from '../components/TwoFactorSettings.vue';
-import {useRoute, useRouter} from 'vue-router';
 
 export default {
   name: 'SettingsPage',

--- a/routes/SettingsPage.vue
+++ b/routes/SettingsPage.vue
@@ -124,7 +124,7 @@ import {profileManager} from '@bedrock/web-wallet';
 import ProfileSettings from '../components/ProfileSettings.vue';
 import SettingsModule from '../components/SettingsModule.vue';
 import TwoFactorSettings from '../components/TwoFactorSettings.vue';
-import {useRoute, useRouter} from 'vue-router'
+import {useRoute, useRouter} from 'vue-router';
 
 export default {
   name: 'SettingsPage',
@@ -167,7 +167,7 @@ export default {
     watch(
       () => activeProfile.value,
       profile => {
-        settingsSelection.value = profile?.id ?? 'account'
+        settingsSelection.value = profile?.id ?? 'account';
         if(!profile) {
           // if no profile is set, change the route to account settings
           router.replace({name: 'settings'});


### PR DESCRIPTION
Fixes the linter to work on `*.vue` files in addition to `*.js` and then lints the project. Also contains a patch release for a minor bug. 

Related: https://github.com/digitalbazaar/eslint-config-digitalbazaar/issues/70

This PR turns off [vue/multi-word-component-names](https://eslint.vuejs.org/rules/multi-word-component-names.html)