### PR TITLE
Update component names from single word to multi-word.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,8 +17,6 @@ module.exports = {
     'digitalbazaar/vue3',
     'plugin:quasar/standard'
   ],
-  rules: {
-    'vue/multi-word-component-names': 0
-  },
+  rules: {},
   ignorePatterns: ['node_modules/']
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-vue-wallet ChangeLog
 
+## 23.0.0 - 2023-11-xx
+
+### Changed
+- **BREAKING**: Rename all single word components to multi-word component names
+  in order to remove ESLint rule exception.
+
 ## 22.2.0 - 2023-11-09
 
 ### Added

--- a/components/CredentialDashboard.vue
+++ b/components/CredentialDashboard.vue
@@ -62,7 +62,7 @@ import CredentialsList from './CredentialsList.vue';
 import SearchBox from './SearchBox.vue';
 
 export default {
-  name: 'Credentials',
+  name: 'CredentialDashboard',
   components: {
     BrQTitleCard,
     CredentialsList,

--- a/components/InteractDashboard.vue
+++ b/components/InteractDashboard.vue
@@ -74,7 +74,7 @@ const payload = {
 */
 
 export default {
-  name: 'Interact',
+  name: 'InteractDashboard',
   components: {QrCode},
   props: {},
   data() {

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -210,7 +210,7 @@ import {session} from '@bedrock/web-session';
 import useVuelidate from '@vuelidate/core';
 
 export default {
-  name: 'Login',
+  name: 'LoginForm',
   components: {CodeInput, BrQTitleCard},
   emits: ['login', 'register'],
   setup() {

--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -53,7 +53,7 @@
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
 export default {
-  name: 'Drawer',
+  name: 'NavigationDrawer',
   props: {
     account: {
       type: String,

--- a/components/ProblemCard.vue
+++ b/components/ProblemCard.vue
@@ -66,7 +66,7 @@
  * Copyright (c) 2015-2022 Digital Bazaar, Inc. All rights reserved.
  */
 export default {
-  name: 'Problem',
+  name: 'ProblemCard',
   props: {
     account: {
       type: String,

--- a/components/ProfileDashboard.vue
+++ b/components/ProfileDashboard.vue
@@ -99,7 +99,7 @@ const columns = [
 ];
 
 export default {
-  name: 'Profiles',
+  name: 'ProfileDashboard',
   components: {
     SearchBox,
     AddProfileModal,

--- a/components/RegisterForm.vue
+++ b/components/RegisterForm.vue
@@ -122,7 +122,7 @@ import useVuelidate from '@vuelidate/core';
 const {createProfile} = helpers;
 
 export default {
-  name: 'Register',
+  name: 'RegisterForm',
   components: {BrQTitleCard},
   emits: ['login', 'register'],
   setup() {

--- a/components/WalletLayout.vue
+++ b/components/WalletLayout.vue
@@ -22,7 +22,7 @@
         v-model="showDrawer"
         class="lt-md"
         side="left">
-        <drawer
+        <navigation-drawer
           :logout="logout"
           :account="account" />
       </q-drawer>
@@ -39,15 +39,15 @@
  */
 import {session, sessionDataRef} from '../lib/session.js';
 import {computed} from 'vue';
-import Drawer from './Drawer.vue';
+import NavigationDrawer from './NavigationDrawer.vue';
 import {rootData} from '../lib/rootData.js';
 import WalletHeader from './WalletHeader.vue';
 
 export default {
   name: 'WalletLayout',
   components: {
-    Drawer,
-    WalletHeader
+    WalletHeader,
+    NavigationDrawer
   },
   setup() {
     const account = computed(() => {

--- a/routes/ChapiExchangePage.vue
+++ b/routes/ChapiExchangePage.vue
@@ -46,7 +46,7 @@
         v-if="display === 'login'"
         @login="$event.waitUntil(login())"
         @register="setDisplay('register')" />
-      <register
+      <register-form
         v-if="display === 'register'"
         @login="setDisplay('login')"
         @register="$event.waitUntil(login())" />
@@ -66,7 +66,7 @@ import ChapiHeader from '../components/ChapiHeader.vue';
 import LoginForm from '../components/LoginForm.vue';
 import ProblemCard from '../components/ProblemCard.vue';
 import {receiveCredentialEvent} from 'web-credential-handler';
-import Register from '../components/Register.vue';
+import RegisterForm from '../components/RegisterForm.vue';
 import ShareCredentials from '../components/ShareCredentials.vue';
 import StoreCredentials from '../components/StoreCredentials.vue';
 import {useQuasar} from 'quasar';
@@ -82,7 +82,7 @@ export default {
     ChapiHeader,
     LoginForm,
     ProblemCard,
-    Register,
+    RegisterForm,
     ShareCredentials,
     StoreCredentials
   },

--- a/routes/ChapiExchangePage.vue
+++ b/routes/ChapiExchangePage.vue
@@ -18,7 +18,7 @@
           :request="relyingPartyRequest" />
         <q-separator class="s-separator" />
       </div>
-      <problem
+      <problem-card
         v-if="error"
         :account="account"
         :loading="loading"
@@ -64,7 +64,7 @@ import {
 } from '@bedrock/web-wallet';
 import ChapiHeader from '../components/ChapiHeader.vue';
 import LoginForm from '../components/LoginForm.vue';
-import Problem from '../components/Problem.vue';
+import ProblemCard from '../components/ProblemCard.vue';
 import {receiveCredentialEvent} from 'web-credential-handler';
 import Register from '../components/Register.vue';
 import ShareCredentials from '../components/ShareCredentials.vue';
@@ -81,7 +81,7 @@ export default {
   components: {
     ChapiHeader,
     LoginForm,
-    Problem,
+    ProblemCard,
     Register,
     ShareCredentials,
     StoreCredentials

--- a/routes/ChapiExchangePage.vue
+++ b/routes/ChapiExchangePage.vue
@@ -42,7 +42,7 @@
       v-else-if="!loading"
       class="full-width q-pa-md"
       style="max-width: 500px">
-      <login
+      <login-form
         v-if="display === 'login'"
         @login="$event.waitUntil(login())"
         @register="setDisplay('register')" />
@@ -63,7 +63,7 @@ import {
   exchanges, getCredentialStore, helpers, profileManager
 } from '@bedrock/web-wallet';
 import ChapiHeader from '../components/ChapiHeader.vue';
-import Login from '../components/Login.vue';
+import LoginForm from '../components/LoginForm.vue';
 import Problem from '../components/Problem.vue';
 import {receiveCredentialEvent} from 'web-credential-handler';
 import Register from '../components/Register.vue';
@@ -79,7 +79,12 @@ const {prettify} = helpers;
 export default {
   name: 'ChapiExchangePage',
   components: {
-    ChapiHeader, Login, Problem, Register, ShareCredentials, StoreCredentials
+    ChapiHeader,
+    LoginForm,
+    Problem,
+    Register,
+    ShareCredentials,
+    StoreCredentials
   },
   props: {
     account: {

--- a/routes/HomePage.vue
+++ b/routes/HomePage.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <credentials
+    <credential-dashboard
       :credentials="credentials"
       :profiles="profiles"
       :loading="loading"
@@ -20,11 +20,11 @@ import {
 } from '@bedrock/web-wallet';
 import {computed, ref, toRef, watch} from 'vue';
 import {computedAsync} from '@vueuse/core';
-import Credentials from '../components/Credentials.vue';
+import CredentialDashboard from '../components/CredentialDashboard.vue';
 
 export default {
   name: 'HomePage',
-  components: {Credentials},
+  components: {CredentialDashboard},
   props: {
     account: {
       type: String,

--- a/routes/InteractPage.vue
+++ b/routes/InteractPage.vue
@@ -6,7 +6,7 @@
         title="Interact"
         class="full-width">
         <template #body>
-          <interact />
+          <interact-dashboard />
         </template>
         <template #icon>
           <q-btn
@@ -63,12 +63,12 @@
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQModal, BrQTitleCard} from '@bedrock/quasar-components';
-import Interact from '../components/Interact.vue';
+import InteractDashboard from '../components/InteractDashboard.vue';
 
 export default {
   name: 'InteractPage',
   components: {
-    Interact,
+    InteractDashboard,
     BrQTitleCard,
     BrQModal
   },

--- a/routes/LoginPage.vue
+++ b/routes/LoginPage.vue
@@ -4,7 +4,7 @@
     <div
       class="full-width"
       style="max-width: 500px">
-      <login
+      <login-form
         @login="$event.waitUntil(login())"
         @register="$event.waitUntil(register())" />
     </div>
@@ -15,11 +15,11 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import Login from '../components/Login.vue';
+import LoginForm from '../components/LoginForm.vue';
 
 export default {
   name: 'LoginPage',
-  components: {Login},
+  components: {LoginForm},
   props: {
     account: {
       type: String,

--- a/routes/OnboardPage.vue
+++ b/routes/OnboardPage.vue
@@ -31,7 +31,7 @@
         <div
           class="row justify-center q-pa-md q-mx-auto"
           style="max-width: 500px">
-          <login @login="$event.waitUntil(claim())" />
+          <login-form @login="$event.waitUntil(claim())" />
         </div>
       </div>
     </div>
@@ -49,13 +49,13 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQTitleCard} from '@bedrock/quasar-components';
-import Login from '../components/Login.vue';
+import LoginForm from '../components/LoginForm.vue';
 import {ProfileService} from '@bedrock/web-profile';
 import {session} from '@bedrock/web-session';
 
 export default {
   name: 'OnboardPage',
-  components: {Login, BrQTitleCard},
+  components: {LoginForm, BrQTitleCard},
   data() {
     return {
       email: '',

--- a/routes/ProfilesPage.vue
+++ b/routes/ProfilesPage.vue
@@ -6,7 +6,7 @@
         title="Profiles"
         class="full-width">
         <template #body>
-          <profiles />
+          <profile-dashboard />
         </template>
       </br-q-title-card>
     </div>
@@ -18,12 +18,12 @@
  * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {BrQTitleCard} from '@bedrock/quasar-components';
-import Profiles from '../components/Profiles.vue';
+import ProfileDashboard from '../components/ProfileDashboard.vue';
 
 export default {
   name: 'ProfilesPage',
   components: {
-    Profiles,
+    ProfileDashboard,
     BrQTitleCard
   }
 };

--- a/routes/RegisterPage.vue
+++ b/routes/RegisterPage.vue
@@ -4,7 +4,7 @@
     <div
       class="full-width"
       style="max-width: 500px">
-      <register
+      <register-form
         @login="$event.waitUntil(login())"
         @register="$event.waitUntil(register())" />
     </div>
@@ -15,14 +15,14 @@
 /*!
  * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
  */
-import Register from '../components/Register.vue';
+import RegisterForm from '../components/RegisterForm.vue';
 import {session} from '@bedrock/web-session';
 import {useQuasar} from 'quasar';
 import {useRouter} from 'vue-router';
 
 export default {
   name: 'RegisterPage',
-  components: {Register},
+  components: {RegisterForm},
   setup() {
     const router = useRouter();
     const $q = useQuasar();


### PR DESCRIPTION
#### _Resolves #40_

_____

### What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Removes the ESLint rule exception for `vue/multi-word-component-names`.

<br/>

### What is the current behavior? (You can also link to an open issue here)
- There are seven components that have a single word name: "Credentials", "Drawer", "Interact", "Login", "Problem", "Profiles", and "Register".

<br/>

### What is the new behavior?
- These components have been renamed:
> - Credentials to CredentialDashboard
> - Drawer to NavigationDrawer
> - Interact to InteractDashboard
> - Login to LoginForm
> - Problem to ProblemCard
> - Profiles to ProfileDashboard
> - Register to RegisterForm

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
- Yes, import statements for these components will not work with the old component names.

<br/>

### Screenshots:
> n/a