### PR TITLE
Update profile chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 21.2.1 - 2023-10-xx
+
+### Added
+- Limit profile chooser to read-only if only one profile is available.
+
 ## 22.1.0 - 2023-10-dd
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-wallet ChangeLog
 
-## 22.1.0 - 2023-10-xx
+## 22.2.0 - 2023-10-dd
 
 ### Added
 - Limit profile chooser to read-only if only one profile is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-wallet ChangeLog
 
-## 22.0.1 - 2023-10-xx
+## 22.1.0 - 2023-10-xx
 
 ### Added
 - Limit profile chooser to read-only if only one profile is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-wallet ChangeLog
 
-## 21.2.1 - 2023-10-xx
+## 22.0.1 - 2023-10-xx
 
 ### Added
 - Limit profile chooser to read-only if only one profile is available.

--- a/components/ProfileChooser.vue
+++ b/components/ProfileChooser.vue
@@ -5,7 +5,8 @@
       dense
       filled
       :options="profiles"
-      :disable="loading"
+      :readonly="oneProfileAvailable"
+      :disable="loading || oneProfileAvailable"
       :label="loading ? 'Loading...' : 'Select a profile'"
       class="s-profile-select text-subtitle1"
       @update:model-value="selectProfile">
@@ -73,6 +74,9 @@ export default {
     };
   },
   computed: {
+    oneProfileAvailable() {
+      return this.profiles.length < 2;
+    },
     selectedProfile: {
       get() {
         return this.selected ? {...this.selected} : null;

--- a/components/ProfileChooser.vue
+++ b/components/ProfileChooser.vue
@@ -82,7 +82,7 @@ export default {
       if(this.loading) {
         return 'Loading...';
       } else if(this.oneProfileAvailable) {
-        return 'Selected Profile';
+        return 'Profile';
       } else {
         return 'Select a profile';
       }

--- a/components/ProfileChooser.vue
+++ b/components/ProfileChooser.vue
@@ -4,6 +4,7 @@
       v-model="selectedProfile"
       dense
       filled
+      :label="inputLabel"
       :options="profiles"
       :readonly="oneProfileAvailable"
       :disable="loading || oneProfileAvailable"
@@ -76,6 +77,15 @@ export default {
   computed: {
     oneProfileAvailable() {
       return this.profiles.length < 2;
+    },
+    inputLabel() {
+      if(this.loading) {
+        return 'Loading...';
+      } else if(this.oneProfileAvailable) {
+        return 'Selected Profile';
+      } else {
+        return 'Select a profile';
+      }
     },
     selectedProfile: {
       get() {

--- a/components/ProfileChooser.vue
+++ b/components/ProfileChooser.vue
@@ -7,7 +7,7 @@
       :options="profiles"
       :readonly="oneProfileAvailable"
       :disable="loading || oneProfileAvailable"
-      :label="loading ? 'Loading...' : 'Select a profile'"
+      :hide-dropdown-icon="oneProfileAvailable"
       class="s-profile-select text-subtitle1"
       @update:model-value="selectProfile">
       <template #prepend>


### PR DESCRIPTION
#### _Resolves veres-wallet issue [566](https://github.com/digitalbazaar/veres-wallet/issues/566)_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Update the ProfileChooser to only be selectable if there is more than one profile available.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- The q-select shows a dropdown even though there is only one option available.

<br/>

### What is the new behavior?

- If only one profile is available for the q-select in the profile chooser then the q-select is disabled and read-only with the single profile selected. 
- If only one profile is available, update input label to say "Profile".

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### Screenshots:
_Profile Chooser component with one profile available_
<img src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/4990e6c3-cef0-42e8-b5a4-1b2871059575" alt="screenshot" width="300" />

---

_Updated Profile Chooser component after [suggestions](https://github.com/digitalbazaar/bedrock-vue-wallet/pull/67#issuecomment-1771361921)_
<img src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/ddeeb1bc-fa97-4da0-821f-e094512842d4" width="400" />
