### PR TITLE
Minimum credential popup size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 22.1.1 - 2023-11-dd
+
+### Fixed
+- Include default minimum width on credential card popup title.
+
 ## 22.1.0 - 2023-10-31
 
 ### Added

--- a/components/CredentialCardBundle.vue
+++ b/components/CredentialCardBundle.vue
@@ -280,6 +280,16 @@ $breakpoint-xs: 320px;
   width: 100%;
 }
 
+.s-card-title {
+  /* Anything larger than mobile */
+  @media (min-width: #{$breakpoint-sm}) {
+    min-width: 450px;
+  }
+  @include mobile {
+    min-width: 300px;
+  }
+}
+
 .s-section {
   height: 100%;
   display: flex;


### PR DESCRIPTION
#### _Resolves Credential Size Inconsistency_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Styling fix.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- A credential with a small image will render a tiny popup window revealing inconsistency between credential previews.

<br/>

### What is the new behavior?

- Establish a minimum width for the credential preview popup.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Tested locally in Veres Wallet with a symlink to bedrock-vue-wallet.

<br/>

### Screenshots:

> Before - Credentials of different sizes
>
> <img  alt="before1" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/f87a9462-f4d2-4a0d-9fea-d09de5268540" />
>
> <img  alt="before2" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/710d7a41-c8ca-478a-bb27-cada6ef9c91b" />

> After - Credentials of different sizes
>
> <img  alt="after1" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/47cd5d21-1b48-4b75-ba5e-1099d4696cfb" />
>
> <img  alt="after2" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/ee6276ba-9988-4f28-894f-9f0f9c73985e" />