### PR TITLE
Credential handler alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-vue-wallet ChangeLog
 
+## 22.2.0 - 2023-11-dd
+
+### Fixed
+- Allow credentials with any description length to align title, description, and
+  image correctly in credential list.
+
 ## 23.0.0 - 2023-11-xx
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
-## 22.2.0 - 2023-11-dd
+## 23.0.0 - 2023-11-dd
 
-### Fixed
-- Allow credentials with any description length to align title, description, and
-  image correctly in credential list.
+### Changed
+- **BREAKING**: Allow credentials with any description length to align title,
+  description, and image correctly in credential list.
 
 ## 23.0.0 - 2023-11-xx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
-## 24.0.0 - 2023-11-dd
+## 23.0.0 - 2023-11-dd
 
 ### Changed
 - **BREAKING**: Allow credentials with any description length to align title,
   description, and image correctly in credential list.
-
-## 23.0.0 - 2023-11-dd
-
-### Changed
 - **BREAKING**: Rename all single word components to multi-word component names
   in order to remove ESLint rule exception.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # bedrock-vue-wallet ChangeLog
 
-## 23.0.0 - 2023-11-dd
+## 24.0.0 - 2023-11-dd
 
 ### Changed
 - **BREAKING**: Allow credentials with any description length to align title,
   description, and image correctly in credential list.
 
-## 23.0.0 - 2023-11-xx
+## 23.0.0 - 2023-11-dd
 
 ### Changed
 - **BREAKING**: Rename all single word components to multi-word component names

--- a/components/CredentialCardBundle.vue
+++ b/components/CredentialCardBundle.vue
@@ -69,7 +69,7 @@ import {
 const {generateQrCodeDataUrl, reissue} = ageCredentialHelpers;
 
 export default {
-  name: 'CredentialsList',
+  name: 'CredentialCardBundle',
   components: {
     CredentialSwitch
   },

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -25,7 +25,7 @@ import {CredentialSwitch} from '@bedrock/vue-vc';
 import {toRef} from 'vue';
 
 export default {
-  name: 'CredentialsList',
+  name: 'CredentialCompactBundle',
   components: {
     CredentialSwitch,
   },

--- a/components/CredentialCompactBundle.vue
+++ b/components/CredentialCompactBundle.vue
@@ -3,7 +3,6 @@
     <div
       v-for="(credential, index) in filteredCredentials"
       :key="index"
-      style="max-width: 400px"
       class="q-my-sm q-gutter-y-sm column">
       <slot
         name="credential-switch"

--- a/components/CredentialSelect.vue
+++ b/components/CredentialSelect.vue
@@ -7,7 +7,7 @@
         :model-value="selectedCredentials"
         @click="toggleSelect(id)" />
     </div>
-    <div>
+    <div style="width: 100%">
       <slot />
     </div>
   </div>


### PR DESCRIPTION
#### _Resolves [567](https://github.com/digitalbazaar/veres-wallet/issues/567) from Veres Wallet_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Styling bug fix.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- A credential with a short title and description will not be in alignment with a credential that has a long enough title to use the entire width of the list item.

<br/>

### What is the new behavior?

- The max width has been removed so the maximum width is controlled by the parent component. The details of the credential in the credential switch component has been updated to have a width of 100% in order to fill the entire list item's width with the details of the credential.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- This has been tested locally by issuing a credential from vc playground to a local veres wallet as well as requesting verifiable presentation from vc playground to a local veres wallet.

<br/>

### Screenshots:

> BEFORE: Credentials with short title and descriptions
> 
> <img  alt="before" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/6bd98d58-0076-458b-9737-929dbea4fe1f" />

<br/>

> AFTER: Credentials with short title and descriptions and updated width properties
> 
> <img  alt="after" width="500" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/b35615c8-670b-4bb4-b61d-d66ae3a899d7" />