### PR TITLE
Max token error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 22.2.0 - 2023-11-dd
+
+### Added
+- Communicates send email code errors to user on login.
+
 ## 22.1.1 - 2023-11-02
 
 ### Fixed

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -248,7 +248,9 @@ export default {
         twoFactorLogin: false
       },
       showEmailCodeAuthenticated: false,
-      awaitingAuthorization: false
+      awaitingAuthorization: false,
+      customErrorMessage:
+        'Too many login requests, check your email for a login code.'
     };
   },
   computed: {
@@ -318,15 +320,17 @@ export default {
           });
         }
       } catch(e) {
-        errorMessage = e.message;
         console.error('sendEmail error', e);
+        errorMessage = e.message.includes('No more than 5 tokens') ?
+          this.customErrorMessage : e.message;
         this.$q.notify({
+          timeout: 0,
           type: 'negative',
           message: errorMessage,
           actions: [{icon: 'fa fa-times', color: 'white'}]
         });
       }
-      if(errorMessage && !errorMessage.includes('No more than 5 tokens')) {
+      if(errorMessage && errorMessage !== this.customErrorMessage) {
         this.reset();
       } else {
         this.showSendEmail = false;

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -296,10 +296,10 @@ export default {
       this.showDeviceAlreadyRegistered = false;
     },
     async sendEmail() {
+      let errorMessage = '';
       try {
         const {email} = this.ctrl;
         this.loading.emailCode = true;
-
         if(this.deviceRegistrationRequired) {
           // create nonce for device registration; it will send email as well;
           // note this is a legacy feature for older accounts only
@@ -317,18 +317,25 @@ export default {
             authenticationMethod: 'login-email-challenge'
           });
         }
-
+      } catch(e) {
+        errorMessage = e.message;
+        console.error('sendEmail error', e);
+        this.$q.notify({
+          type: 'negative',
+          message: errorMessage,
+          actions: [{icon: 'fa fa-times', color: 'white'}]
+        });
+      }
+      if(errorMessage && !errorMessage.includes('No more than 5 tokens')) {
+        this.reset();
+      } else {
         this.showSendEmail = false;
         this.showResendEmail = true;
         this.showRegisterLink = false;
         this.showEmailCode = true;
         this.emailCode = '';
-      } catch(e) {
-        console.error('sendEmail error', e);
-        this.reset();
-      } finally {
-        this.loading.emailCode = false;
       }
+      this.loading.emailCode = false;
     },
     handleEnterForEmail() {
       if(this.loading.emailCode || this.vuelidate.ctrl.email.$invalid) {


### PR DESCRIPTION
#### _Resolves #45 & Resolves [529](https://github.com/digitalbazaar/veres-wallet/issues/529) from Veres Wallet_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Bug fix to allow user to see email code error and continue with the login process.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- A max of 5 email tokens can be sent to a user to login. If this limit is exceeded no more tokens will be sent and the form is reset not allowing a user to enter a previously sent email token.

<br/>

### What is the new behavior?

- A user will now be notified of any error when the send email function is not completed successfully. Additionally, if the user sends themself more than 5 tokens, the max token error will be shown and the user can still go to their inbox and utilize the latest email token to continue the login process.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- This has been tested locally with Veres Wallet. This update can handle errors pertaining to the max of 5 outstanding email tokens as well as other errors in the login process.

<br/>

### Screenshots:

> Notification when too many email token requests have been made
> 
> <img  alt="error_notification" width="600" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/fe890761-424d-4615-9e9d-e66495ab2e97" />