### PR TITLE
Simplify header with hide navigation prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 23.1.0 - 2023-11-xx
+
+### Added
+- Render a non-selectable header with logo and title to CHAPI handler windows.
+
 ## 23.0.0 - 2023-11-10
 
 ### Changed

--- a/components/WalletHeader.vue
+++ b/components/WalletHeader.vue
@@ -137,10 +137,6 @@ $breakpoint-xs: 599px;
   }
 }
 
-.non-selectable {
-  cursor: pointer;
-}
-
 .profile-name {
   line-height: 14px !important;
   text-transform: none;

--- a/components/WalletHeader.vue
+++ b/components/WalletHeader.vue
@@ -1,8 +1,7 @@
 <template>
-  <q-toolbar
-    class="bg-secondary">
+  <q-toolbar class="bg-secondary">
     <q-btn
-      v-show="account"
+      v-show="account && !hideNavigation"
       flat
       round
       dense
@@ -11,8 +10,8 @@
       class="toggle-drawer-btn lt-md"
       @click="toggleDrawer()" />
     <q-toolbar-title
-      class="row cursor-pointer"
-      @click="home()">
+      class="row"
+      @click="!hideNavigation && home()">
       <img
         v-if="branding.logo"
         :src="branding.logo"
@@ -23,7 +22,7 @@
       </div>
     </q-toolbar-title>
     <q-btn-toggle
-      v-if="account"
+      v-if="account && !hideNavigation"
       v-model="navRouteName"
       color="accent"
       toggle-color="info"
@@ -37,7 +36,7 @@
       ]"
       @click="handleNav()" />
     <q-btn
-      v-else
+      v-else-if="!hideNavigation"
       flat
       no-wrap
       color="info"
@@ -67,6 +66,10 @@ export default {
     toggleDrawer: {
       type: Function,
       default: undefined
+    },
+    hideNavigation: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -132,6 +135,10 @@ $breakpoint-xs: 599px;
   @media (min-width: 0) and (max-width: #{$breakpoint-sm}) {
     @content;
   }
+}
+
+.non-selectable {
+  cursor: pointer;
 }
 
 .profile-name {

--- a/components/WalletLayout.vue
+++ b/components/WalletLayout.vue
@@ -3,11 +3,12 @@
     view="hHh LpR fFf"
     class="s-page">
     <q-header
-      v-if="ready && !chapi"
+      v-if="ready"
       class="shadow-3">
       <wallet-header
-        :account="account"
         :logout="logout"
+        :account="account"
+        :hide-navigation="chapi"
         :toggle-drawer="toggleDrawer" />
     </q-header>
 


### PR DESCRIPTION
#### _Resolves #74_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Styling update.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- There is no header in the CHAPI handler windows.

<br/>

### What is the new behavior?

- A simplified header has been added to the CHAPI handler windows that has no navigation options or selectable buttons. It displays the app logo and title to aid in the confidence of the UX.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- It has been tested locally by issuing a credential from the VC Playground to a local Veres Wallet.

<br/>

### Screenshots:

> Local CHAPI handler window with app bar
> 
> <img  alt="screenshot" width="600" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/fdca3e86-e0fa-4472-8289-09a5b1e5af3f" />
