### PR TITLE
Add conditional to handle nameless credential.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 25.0.1 - 2024-01-dd
+
+### Fixed
+- Allow nameless credential with only one type to render.
+
 ## 25.0.0 - 2023-12-14
 
 ### Changed

--- a/components/CredentialDashboard.vue
+++ b/components/CredentialDashboard.vue
@@ -102,7 +102,7 @@ export default {
       emit('filtered-credentials-loading', true);
       const filteredCredentials = credentials.value.filter(({credential}) => {
         if(credential) {
-          const credentialName = credential.name || credential.type[1];
+          const credentialName = credential.name || credential.type[1] || '';
           return credentialName.toLowerCase().includes(
             search.value.toLowerCase());
         }


### PR DESCRIPTION
#### _Resolves - bug fix for nameless single type credentials_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Bug fix.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- If a credential doesn't have a name property and only 1 type in its type array then the credential doesn't render in the wallet UI.

<br/>

### What is the new behavior?

- Credential checks for name, then second type in type array, then defaults to empty string allowing the UI to still render if these fields are missing.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- I issued myself a credential through the custom credential option that did not have a name property and only had one type ('VerifiableCredential') and it was still able to render in my wallet locally.

<br/>

### Screenshots:

> Nameless Credential
> 
> <img  alt="nameless credential" width="400" src="https://github.com/digitalbazaar/bedrock-vue-wallet/assets/56396286/1e212d7a-80c6-4f9b-8d2d-d97195e26aa3" />