### PR TITLE
Add multiple detail window views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 28.1.0 - 2024-04-dd
+
+### Changed
+- Update credential details window to use three tabs for different display options.
+
 ## 28.0.1 - 2024-04-03
 
 ### Fixed

--- a/components/CredentialCardBundle.vue
+++ b/components/CredentialCardBundle.vue
@@ -26,6 +26,7 @@
         :card-styles="cardStyles"
         :show-details="showDetails"
         :card-background="cardBackground"
+        :credential-images="credentialImages"
         :credential="credentialRecord.credential"
         :toggle-delete-window="toggleDeleteWindow"
         :credential-overrides="credentialOverrides"
@@ -122,6 +123,7 @@ export default {
     const showDelete = ref(false);
     const showDetails = ref(false);
     const currentCardProfile = ref({});
+    const credentialImages = reactive([]);
     const credentialHighlights = reactive({});
     const cardStyles = reactive({textColor: '', backgroundColor: ''});
     const credentialOverrides = reactive({
@@ -135,9 +137,10 @@ export default {
     onBeforeMount(() => {
       const vcConfig = getCredentialConfig();
       if(vcConfig) {
-        const {styles, overrides, highlights} = vcConfig;
+        const {styles, images, overrides, highlights} = vcConfig;
         setCardStyles(styles);
         setCardOverrides(overrides);
+        getCredentialImages(images);
         getCredentialHighlights(highlights);
       }
     });
@@ -196,6 +199,17 @@ export default {
         const {pointer, format, joinWith} = detail;
         const value = getValueFromPointer(credential, pointer, joinWith);
         credentialHighlights[detail.field] = formatString(value, format);
+      });
+    }
+
+    // Get details from credential
+    function getCredentialImages(images = []) {
+      images.forEach(imagePointer => {
+        const {credential} = props.credentialRecord;
+        const image = getValueFromPointer(credential, imagePointer);
+        if(image) {
+          credentialImages.push(image);
+        }
       });
     }
 
@@ -350,6 +364,7 @@ export default {
       currentCard,
       cardBackground,
       deleteCredential,
+      credentialImages,
       currentCardProfile,
       toggleDeleteWindow,
       credentialOverrides,

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -10,8 +10,8 @@
         round
         color="dark"
         icon="fa fa-times"
-        style="font-size: 0.75em"
-        class="absolute-top-right q-ma-sm" />
+        class="absolute-top-right q-ma-sm"
+        style="font-size: 0.75em; z-index: 1;" />
       <!-- Left side details -->
       <div class="col-xs-12 col-md-5 bg-white q-pt-xl q-pb-md q-px-xl">
         <div class="row justify-center items-start full-height">
@@ -52,35 +52,10 @@
         </div>
       </div>
       <!-- Right side details -->
-      <div class="col bg-grey-2 q-pa-xl">
-        <div class="row justify-start items-start">
-          <q-scroll-area
-            visible
-            :thumb-style="scrollBarStyles"
-            class="highlights rounded-borders">
-            <q-card-section class="q-py-none text-body1 fit">
-              <div
-                v-for="(value, key, index) in credentialHighlights"
-                :key="key"
-                :class="[index !== 0 && 'q-mt-md']">
-                <img
-                  v-if="key.includes('image')"
-                  :src="value"
-                  style="width: 130px;"
-                  class="rounded-borders">
-                <div v-else>
-                  <div class="text-grey text-body2">
-                    {{key}}
-                  </div>
-                  <div class="text-body1">
-                    {{value}}
-                  </div>
-                </div>
-              </div>
-            </q-card-section>
-          </q-scroll-area>
-        </div>
-      </div>
+      <CredentialDetailsViews
+        :credential="credential"
+        :credential-overrides="credentialOverrides"
+        :credential-highlights="credentialHighlights" />
     </div>
   </q-card>
 </template>
@@ -90,24 +65,18 @@
  * Copyright (c) 2015-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, ref} from 'vue';
+import CredentialDetailsViews from './CredentialDetailsViews.vue';
 import {CredentialSwitch} from '@bedrock/vue-vc';
 
 export default {
   name: 'CredentialDetails',
   components: {
-    CredentialSwitch
+    CredentialSwitch,
+    CredentialDetailsViews
   },
   props: {
-    toggleDetailsWindow: {
-      type: Function,
-      required: true
-    },
     toggleDeleteWindow: {
       type: Function,
-      required: true
-    },
-    showDetails: {
-      type: Boolean,
       required: true
     },
     credential: {
@@ -142,17 +111,7 @@ export default {
   },
   setup(props) {
     // Local state
-    const qrUrl = ref('');
     const showDelete = ref(false);
-
-    // Scroll area bar style
-    const scrollBarStyles = {
-      right: '2px',
-      width: '3px',
-      opacity: '0.4',
-      borderRadius: '5px',
-      backgroundColor: 'gray',
-    };
 
     // Credential description
     const description = computed(() => {
@@ -165,10 +124,8 @@ export default {
     });
 
     return {
-      qrUrl,
       showDelete,
-      description,
-      scrollBarStyles
+      description
     };
   }
 };
@@ -176,14 +133,6 @@ export default {
 
 <style lang="scss" scoped>
 $breakpoint-sm: 767px;
-$breakpoint-xs: 360px;
-
-@mixin mobile {
-  @media (min-width: #{$breakpoint-xs}) and (max-width: #{$breakpoint-sm}) {
-    @content;
-  }
-}
-
 .details-dialog {
   /* Apply styles when dialog is not full screen */
   @media (min-width: #{$breakpoint-sm}) {
@@ -194,7 +143,6 @@ $breakpoint-xs: 360px;
     max-height: 80vh;
   }
 }
-
 .card {
   /* Credit card ratio 2.125 H by 3.375 W */
   width: 275px;
@@ -203,10 +151,5 @@ $breakpoint-xs: 360px;
   aspect-ratio: 3.375 / 2.125;
   background-color: #FFFFFF;
   border: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-.highlights {
-  width: 100%;
-  height: 404px;
 }
 </style>

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -54,6 +54,7 @@
       <!-- Right side details -->
       <CredentialDetailsViews
         :credential="credential"
+        :credential-images="credentialImages"
         :credential-overrides="credentialOverrides"
         :credential-highlights="credentialHighlights" />
     </div>
@@ -94,6 +95,10 @@ export default {
     cardBackground: {
       type: String,
       default: ''
+    },
+    credentialImages: {
+      type: Array,
+      default: () => []
     },
     credentialHighlights: {
       type: Object,
@@ -137,8 +142,8 @@ $breakpoint-sm: 767px;
   /* Apply styles when dialog is not full screen */
   @media (min-width: #{$breakpoint-sm}) {
     border-radius: 12px;
-    width: 800px;
-    height: 500px;
+    width: 850px;
+    height: 600px;
     max-width: 80vw;
     max-height: 80vh;
   }

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="col bg-grey-2 q-pa-md">
+    <q-tabs
+      v-model="tab"
+      dense
+      align="justify"
+      narrow-indicator
+      active-color="primary"
+      class="text-grey q-px-xl"
+      indicator-color="primary">
+      <q-tab
+        no-caps
+        name="highlights"
+        label="Highlights" />
+      <q-tab
+        no-caps
+        name="images"
+        label="Images" />
+      <q-tab
+        no-caps
+        name="details"
+        label="Details" />
+    </q-tabs>
+
+    <q-separator />
+
+    <q-tab-panels
+      v-model="tab"
+      animated>
+      <q-tab-panel
+        name="highlights"
+        class="bg-grey-2">
+        <div class="row justify-start items-start">
+          <q-scroll-area
+            visible
+            :thumb-style="scrollBarStyles"
+            class="details-view rounded-borders">
+            <q-card-section class="q-py-none text-body1 fit">
+              <div
+                v-for="(value, key, index) in credentialHighlights"
+                :key="key"
+                :class="[index !== 0 && 'q-mt-md']">
+                <img
+                  v-if="key.includes('image')"
+                  :src="value"
+                  style="width: 130px;"
+                  class="rounded-borders">
+                <div v-else>
+                  <div class="text-grey text-body2">
+                    {{key}}
+                  </div>
+                  <div class="text-body1">
+                    {{value}}
+                  </div>
+                </div>
+              </div>
+            </q-card-section>
+          </q-scroll-area>
+        </div>
+      </q-tab-panel>
+
+      <q-tab-panel
+        name="images"
+        class="bg-grey-2">
+        <div class="details-view">
+          Credential images are not currently available.
+        </div>
+      </q-tab-panel>
+
+      <q-tab-panel
+        name="details"
+        class="bg-grey-2">
+        <div class="details-view">
+          Details view is not currently available.
+        </div>
+      </q-tab-panel>
+    </q-tab-panels>
+  </div>
+</template>
+
+<script>
+/*!
+ * Copyright (c) 2015-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import {ref} from 'vue';
+
+export default {
+  name: 'CredentialDetailsViews',
+  components: {},
+  props: {
+    credential: {
+      type: Object,
+      required: true
+    },
+    images: {
+      type: Array,
+      default: () => []
+    },
+    credentialHighlights: {
+      type: Object,
+      required: true
+    },
+    credentialOverrides: {
+      type: Object,
+      default: () => ({
+        title: '',
+        image: '',
+        subtitle: '',
+        description: '',
+      })
+    },
+  },
+  setup() {
+    // Local state
+    const tab = ref('highlights');
+
+    // Scroll area bar style
+    const scrollBarStyles = {
+      right: '2px',
+      width: '3px',
+      opacity: '0.4',
+      borderRadius: '5px',
+      backgroundColor: 'gray',
+    };
+
+    return {
+      tab,
+      scrollBarStyles
+    };
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.details-view {
+  width: 100%;
+  height: 390px;
+}
+</style>

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -22,8 +22,7 @@
         label="Details" />
     </q-tabs>
 
-    <q-separator />
-
+    <!-- Highlights -->
     <q-tab-panels
       v-model="tab"
       animated>
@@ -59,14 +58,52 @@
         </div>
       </q-tab-panel>
 
+      <!-- Image carousel -->
       <q-tab-panel
         name="images"
-        class="bg-grey-2">
-        <div class="details-view">
-          Credential images are not currently available.
+        class="bg-grey-2 q-px-none text-center">
+        <div
+          class="details-view">
+          <q-carousel
+            v-model="slideNumber"
+            v-model:fullscreen="fullscreen"
+            infinite
+            animated
+            swipeable
+            navigation
+            control-color="dark"
+            class="bg-grey-2 q-mb-none fit"
+            navigation-icon="far fa-circle">
+            <q-carousel-slide
+              v-for="(image, index) in credentialImages"
+              :key="image"
+              :name="index + 1"
+              class="q-pa-none">
+              <q-scroll-area class="fit bg-grey-2">
+                <img
+                  :src="image"
+                  class="q-mx-auto rounded-borders"
+                  style="max-width: 100%; pointer-events: none;">
+              </q-scroll-area>
+            </q-carousel-slide>
+            <template #control>
+              <q-carousel-control
+                position="bottom-right"
+                :offset="[18, 18]">
+                <q-btn
+                  round
+                  dense
+                  color="white"
+                  text-color="dark"
+                  :icon="fullscreen ? 'fa fa-compress' : 'fa fa-expand'"
+                  @click="fullscreen = !fullscreen" />
+              </q-carousel-control>
+            </template>
+          </q-carousel>
         </div>
       </q-tab-panel>
 
+      <!-- Details -->
       <q-tab-panel
         name="details"
         class="bg-grey-2">
@@ -92,7 +129,7 @@ export default {
       type: Object,
       required: true
     },
-    images: {
+    credentialImages: {
       type: Array,
       default: () => []
     },
@@ -112,7 +149,9 @@ export default {
   },
   setup() {
     // Local state
+    const slideNumber = ref(1);
     const tab = ref('highlights');
+    const fullscreen = ref(false);
 
     // Scroll area bar style
     const scrollBarStyles = {
@@ -125,6 +164,8 @@ export default {
 
     return {
       tab,
+      fullscreen,
+      slideNumber,
       scrollBarStyles
     };
   }
@@ -134,6 +175,6 @@ export default {
 <style lang="scss" scoped>
 .details-view {
   width: 100%;
-  height: 390px;
+  height: 500px;
 }
 </style>

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -73,6 +73,8 @@
             swipeable
             navigation
             control-color="dark"
+            transition-next="slide-left"
+            transition-prev="slide-right"
             class="bg-grey-2 q-mb-none fit"
             navigation-icon="far fa-circle">
             <q-carousel-slide

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -67,6 +67,7 @@
           <q-carousel
             v-model="slideNumber"
             v-model:fullscreen="fullscreen"
+            padding
             infinite
             animated
             swipeable
@@ -80,10 +81,12 @@
               :name="index + 1"
               class="q-pa-none">
               <q-scroll-area class="fit bg-grey-2">
-                <img
-                  :src="image"
-                  class="q-mx-auto rounded-borders"
-                  style="max-width: 100%; pointer-events: none;">
+                <div class="flex">
+                  <img
+                    :src="image"
+                    class="q-mx-auto rounded-borders"
+                    style="max-width: 100%; pointer-events: none;">
+                </div>
               </q-scroll-area>
             </q-carousel-slide>
             <template #control>

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -14,8 +14,8 @@
         label="Highlights" />
       <q-tab
         no-caps
-        name="images"
-        label="Images" />
+        name="displays"
+        label="Displays" />
       <q-tab
         no-caps
         name="details"
@@ -60,7 +60,7 @@
 
       <!-- Image carousel -->
       <q-tab-panel
-        name="images"
+        name="displays"
         class="bg-grey-2 q-px-none text-center">
         <div
           class="details-view">

--- a/lib/cardDesigns.js
+++ b/lib/cardDesigns.js
@@ -11,6 +11,10 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
+    images: [
+      '/issuer/image',
+      '/credentialSubject/image'
+    ],
     overrides: {
       title: {
         pointer: '/name'
@@ -86,6 +90,7 @@ export const cardDesigns = [
       backgroundColor: '#5352ED',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -130,6 +135,7 @@ export const cardDesigns = [
       backgroundColor: '#182C61',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/credentialSubject/achievement/creator/name'
@@ -197,6 +203,7 @@ export const cardDesigns = [
       backgroundColor: '#2F3542',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -245,6 +252,7 @@ export const cardDesigns = [
       backgroundColor: '#747D8C',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -289,6 +297,7 @@ export const cardDesigns = [
       backgroundColor: '#82589F',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -333,6 +342,7 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -375,6 +385,7 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -427,6 +438,7 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -467,6 +479,7 @@ export const cardDesigns = [
       backgroundColor: '#402A23',
       textColor: '#FFFFFF'
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -502,6 +515,7 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
+    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'


### PR DESCRIPTION
#### _Resolves - allows for image views in credential detail window_

---

### What kind of change does this PR introduce?

- UI update.

<br/>

### What is the current behavior?

- Only highlights are visible for credential detail window.

<br/>

### What is the new behavior?

- Credential detail window now has three tabs for highlights, images, and details.
- The `Images` tab contains an image carousel that will display a credential images from config file.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Locally rendered.

<br/>

### Screenshots: n/a