### PR TITLE
Use renderMethod property for credential displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Update credential details window to use three tabs for different display options.
+- Parse and utilize credential's render method property for image displays.
 
 ## 28.0.1 - 2024-04-03
 

--- a/components/CredentialCardBundle.vue
+++ b/components/CredentialCardBundle.vue
@@ -26,7 +26,6 @@
         :card-styles="cardStyles"
         :show-details="showDetails"
         :card-background="cardBackground"
-        :credential-images="credentialImages"
         :credential="credentialRecord.credential"
         :toggle-delete-window="toggleDeleteWindow"
         :credential-overrides="credentialOverrides"
@@ -123,7 +122,6 @@ export default {
     const showDelete = ref(false);
     const showDetails = ref(false);
     const currentCardProfile = ref({});
-    const credentialImages = reactive([]);
     const credentialHighlights = reactive({});
     const cardStyles = reactive({textColor: '', backgroundColor: ''});
     const credentialOverrides = reactive({
@@ -137,10 +135,9 @@ export default {
     onBeforeMount(() => {
       const vcConfig = getCredentialConfig();
       if(vcConfig) {
-        const {styles, images, overrides, highlights} = vcConfig;
+        const {styles, overrides, highlights} = vcConfig;
         setCardStyles(styles);
         setCardOverrides(overrides);
-        getCredentialImages(images);
         getCredentialHighlights(highlights);
       }
     });
@@ -199,17 +196,6 @@ export default {
         const {pointer, format, joinWith} = detail;
         const value = getValueFromPointer(credential, pointer, joinWith);
         credentialHighlights[detail.field] = formatString(value, format);
-      });
-    }
-
-    // Get details from credential
-    function getCredentialImages(images = []) {
-      images.forEach(imagePointer => {
-        const {credential} = props.credentialRecord;
-        const image = getValueFromPointer(credential, imagePointer);
-        if(image) {
-          credentialImages.push(image);
-        }
       });
     }
 
@@ -364,7 +350,6 @@ export default {
       currentCard,
       cardBackground,
       deleteCredential,
-      credentialImages,
       currentCardProfile,
       toggleDeleteWindow,
       credentialOverrides,

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -54,7 +54,6 @@
       <!-- Right side details -->
       <CredentialDetailsViews
         :credential="credential"
-        :credential-images="credentialImages"
         :credential-overrides="credentialOverrides"
         :credential-highlights="credentialHighlights" />
     </div>
@@ -95,10 +94,6 @@ export default {
     cardBackground: {
       type: String,
       default: ''
-    },
-    credentialImages: {
-      type: Array,
-      default: () => []
     },
     credentialHighlights: {
       type: Object,

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -177,6 +177,7 @@ export default {
       if(props.credential?.renderMethod?.length) {
         props.credential.renderMethod.forEach(rm => {
           if(supportedRenderMethods.includes(rm.type)) {
+            // Uses id for src value in image carousel
             credentialImages.push(rm.id);
           }
         });

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -177,7 +177,7 @@ export default {
       if(props.credential?.renderMethod?.length) {
         props.credential.renderMethod.forEach(rm => {
           if(supportedRenderMethods.includes(rm.type)) {
-            credentialImages.unshift(rm.id);
+            credentialImages.push(rm.id);
           }
         });
       }

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -124,7 +124,7 @@
 /*!
  * Copyright (c) 2015-2024 Digital Bazaar, Inc. All rights reserved.
  */
-import {ref} from 'vue';
+import {onBeforeMount, reactive, ref} from 'vue';
 
 export default {
   name: 'CredentialDetailsViews',
@@ -133,10 +133,6 @@ export default {
     credential: {
       type: Object,
       required: true
-    },
-    credentialImages: {
-      type: Array,
-      default: () => []
     },
     credentialHighlights: {
       type: Object,
@@ -152,11 +148,15 @@ export default {
       })
     },
   },
-  setup() {
+  setup(props) {
     // Local state
     const slideNumber = ref(1);
     const tab = ref('highlights');
     const fullscreen = ref(false);
+    const credentialImages = reactive([]);
+
+    // Constants
+    const supportedRenderMethods = ['SvgRenderingTemplate2023'];
 
     // Scroll area bar style
     const scrollBarStyles = {
@@ -167,11 +167,28 @@ export default {
       backgroundColor: 'gray',
     };
 
+    // Fetch style, overrides, & highlights before component mounts
+    onBeforeMount(() => {
+      getDisplaysFromRenderMethod();
+    });
+
+    // Extract and parse images from credential's render method property
+    async function getDisplaysFromRenderMethod() {
+      if(props.credential?.renderMethod?.length) {
+        props.credential.renderMethod.forEach(rm => {
+          if(supportedRenderMethods.includes(rm.type)) {
+            credentialImages.unshift(rm.id);
+          }
+        });
+      }
+    }
+
     return {
       tab,
       fullscreen,
       slideNumber,
-      scrollBarStyles
+      scrollBarStyles,
+      credentialImages
     };
   }
 };

--- a/lib/cardDesigns.js
+++ b/lib/cardDesigns.js
@@ -11,10 +11,6 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
-    images: [
-      '/issuer/image',
-      '/credentialSubject/image'
-    ],
     overrides: {
       title: {
         pointer: '/name'
@@ -90,7 +86,6 @@ export const cardDesigns = [
       backgroundColor: '#5352ED',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -135,7 +130,6 @@ export const cardDesigns = [
       backgroundColor: '#182C61',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/credentialSubject/achievement/creator/name'
@@ -203,7 +197,6 @@ export const cardDesigns = [
       backgroundColor: '#2F3542',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -252,7 +245,6 @@ export const cardDesigns = [
       backgroundColor: '#747D8C',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -297,7 +289,6 @@ export const cardDesigns = [
       backgroundColor: '#82589F',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -342,7 +333,6 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -385,7 +375,6 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'
@@ -438,7 +427,6 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -479,7 +467,6 @@ export const cardDesigns = [
       backgroundColor: '#402A23',
       textColor: '#FFFFFF'
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/name'
@@ -515,7 +502,6 @@ export const cardDesigns = [
       backgroundColor: '',
       textColor: ''
     },
-    images: [],
     overrides: {
       title: {
         pointer: '/issuer/name'


### PR DESCRIPTION
#### _Resolves - utilize credential's renderMethod property for credential displays_

---

### What kind of change does this PR introduce?

- UI update.

<br/>

### What is the current behavior?

- Credential images are rendered through json pointers to credential properties via config file.

<br/>

### What is the new behavior?

- Iterate through renderMethod property and pass the "id" field to an image component in order to render credential displays.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- A custom credential was created with base64 URI in the `id` field of an object in the renderMethod property array.
- This credential was issued to users wallet.
- Images were displayed in the `Displays` tab of the credential details

<br/>

### Screenshots: n/a