### PR TITLE
Use render method svg templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 28.1.0 - 2024-04-dd
 
 ### Added
+- Add `mustache@4.2.0` dependency for hydrating svg templates with data.
 - Documentation for card design configurations.
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@digitalbazaar/web-app-manifest-utils": "^2.0.0",
+    "mustache": "^4.2.0",
     "qrcode": "^1.5.3",
     "randomcolor": "^0.6.2",
     "web-credential-handler": "^2.0.2"


### PR DESCRIPTION
#### _Resolves - allows for svg templates to be use from vc's renderMethod_

---

### What kind of change does this PR introduce?

- New dependency on mustache.
- UI update.

<br/>

### What is the current behavior?

- Render method is used to display a static svg.

<br/>

### What is the new behavior?

- Render method is parse and mustache is used to hydrate an svg template with data from the verifiable credential.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Locally rendered by issuing a custom naturalization certificate credential with an svg template in its renderMethod property from the vc playground.

<br/>

### Screenshots: n/a