### PR TITLE
Add refresh button for credential dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 28.1.0 - 2024-04-dd
 
 ### Added
+- Add refresh button to credential dashboard.
 - Add `mustache@4.2.0` dependency for hydrating svg templates with data.
 - Documentation for card design configurations.
 

--- a/components/CredentialDashboard.vue
+++ b/components/CredentialDashboard.vue
@@ -2,11 +2,22 @@
   <q-page
     class="row justify-center"
     style="min-height: 0px;">
-    <div class="col-sm-5 col-xs-10 row items-center q-mt-lg q-mb-sm">
-      <search-box
-        class="col-grow"
-        placeholder="Search credentials"
-        @search="search=$event.text" />
+    <div class="row justify-center  full-width q-mt-lg q-mb-sm">
+      <div class="col-md-5 col-sm-6 col-xs-9">
+        <search-box
+          class="col-grow"
+          placeholder="Search credentials"
+          @search="search=$event.text" />
+      </div>
+      <div class="q-mx-sm q-mt-xs">
+        <q-btn
+          round
+          outline
+          size="sm"
+          color="primary"
+          icon="fas fa-sync-alt"
+          @click="refresh" />
+      </div>
     </div>
     <div class="col-xs-12">
       <credentials-list


### PR DESCRIPTION
#### _Resolves - brings back the refresh button on the credential dashboard_

---

### What kind of change does this PR introduce?

- UI update.

<br/>

### What is the current behavior?

- No button is available for credential list refresh. User has to refresh the whole page.

<br/>

### What is the new behavior?

- Small refresh button is located to the right of the search bar to refresh credential list.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Locally.

<br/>

### Screenshots: n/a