### PR TITLE
Format date values in SVG template display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 28.1.1 - 2024-04-dd
+
+### Added
+- Includes ability to format dates in svg display template.
+
 ## 28.1.0 - 2024-04-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-wallet ChangeLog
 
-## 28.1.1 - 2024-04-dd
+## 28.2.0 - 2024-04-dd
 
 ### Added
 - Includes ability to format dates in svg display template.

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -125,7 +125,10 @@
  * Copyright (c) 2015-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {onBeforeMount, reactive, ref} from 'vue';
+import {date} from 'quasar';
 import Mustache from 'mustache';
+
+const {formatDate} = date;
 
 export default {
   name: 'CredentialDetailsViews',
@@ -201,6 +204,20 @@ export default {
       credentialImages.push(srcValue);
     }
 
+    /*
+     * Functions used to format Mustache template values
+     * See: https://github.com/janl/mustache.js#functions
+     *
+     * Example Mustache template use:
+     * {{#formatFnName}}{{valueToFormat}}{{/formatFnName}}
+     */
+    const formattingFunctions = {
+      formatDate: () => (text, render) => {
+        const dateString = render(text);
+        return formatDate(dateString, 'YYYY-MM-DD');
+      }
+    };
+
     /**
      * Load svg from url or template then hydrate with credentialSubject values.
      *
@@ -225,7 +242,8 @@ export default {
         const resp = await fetch(url);
         template = await resp.text();
       }
-      const rv = Mustache.render(template, values);
+
+      const rv = Mustache.render(template, {...values, ...formattingFunctions});
       const image = `data:image/svg+xml;base64,${btoa(rv)}`;
       credentialImages.push(image);
     }


### PR DESCRIPTION
#### _Resolves - Format SVG template date values_

---

### What kind of change does this PR introduce?

- Feature update.

<br/>

### What is the current behavior?

- Dates are not formatted when displayed in a credential SVG template.

<br/>

### What is the new behavior?

- Dates can now be formatted.

Note: The SVG date value must be written with the function name wrapping the value like example below.

```
{{#formatFnName}}{{valueToFormat}}{{/formatFnName}}
```

When the SVG contains the value above, the formatFnName will receive, format, and render the valueToFormat.

_See mustache docs for reference: https://github.com/janl/mustache.js#functions_

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Locally

<br/>

### Screenshots: n/a