### PR TITLE
Add NFC read to suppress OS defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 28.4.1 - yyyy-mm-dd
+
+### Changed
+- Activate an NFC reader if available to suppress OS-level reads.
+
 ## 28.4.0 - 2024-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 28.4.1 - yyyy-mm-dd
 
-### Changed
+### Fixed
 - Activate an NFC reader if available to suppress OS-level reads.
 
 ## 28.4.0 - 2024-07-11

--- a/components/NfcShare.vue
+++ b/components/NfcShare.vue
@@ -55,6 +55,19 @@ export default {
       supportsNfc.value = true;
       // eslint-disable-next-line no-undef
       ndef = new NDEFReader();
+
+      // Proactively setup a reader to suppress OS-level reads
+      ndef.scan().catch(error => {
+        console.error(error, 'Failed to setup NDEF reader.');
+      });
+
+      ndef.onreading = event => {
+        console.log('NFC read event:', event);
+      };
+
+      ndef.onreadingerror = event => {
+        console.log(event, 'NDEF reader error.');
+      };
     }
 
     function cancelWrite() {


### PR DESCRIPTION
Attempting to share via NFC currently triggers a read on success, which the OS intercepts and navigates away from the wallet page.

To address, we can activate a read (scan) session to suppress the default behavior while the credential is active.