### PR TITLE
Nfc transfer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 28.6.0 - 2024-07-xx
+
+### Added
+- Update UI to represent nfc transferring credential state. 
+
 ## 28.5.1 - 2024-07-19
 
 ### Fixed

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -26,7 +26,8 @@
                 :image-override="credentialOverrides.image"
                 :description-override="credentialOverrides.subtitle" />
             </q-card>
-            <q-card-section class="flex full-width q-mt-auto justify-center">
+            <q-card-section
+              class="q-px-none q-pb-none flex full-width justify-center">
               <NfcShare :credential="credential" />
             </q-card-section>
             <div class="text-grey q-mt-lg text-body2">

--- a/components/NfcShare.vue
+++ b/components/NfcShare.vue
@@ -4,17 +4,44 @@
       v-if="!isSharing"
       outline
       no-caps
+      rounded
       color="primary"
       icon="fa fa-share"
       label="Share via NFC"
       @click="writeNfc" />
     <div
-      v-else
+      v-if="isSharing && !isTransferring"
       class="text-center">
-      Hold your device near a reader to share your credential.
+      <div class="text-body1">
+        Hold your device near a reader to share your credential.
+      </div>
       <div>
         <q-btn
           outline
+          rounded
+          no-caps
+          class="q-mt-sm"
+          @click="cancelWrite">
+          Cancel
+        </q-btn>
+      </div>
+    </div>
+    <div
+      v-if="isSharing && isTransferring"
+      class="text-center">
+      <div class="q-mb-sm">
+        <q-spinner
+          size="2em"
+          class="q-mb-sm"
+          color="primary" />
+        <div class="text-body1">
+          Sharing credential, please wait...
+        </div>
+      </div>
+      <div>
+        <q-btn
+          outline
+          rounded
           no-caps
           class="q-mt-sm"
           @click="cancelWrite">
@@ -44,6 +71,7 @@ export default {
     // Refs
     const supportsNfc = ref(false);
     const isSharing = ref(false);
+    const isTransferring = ref(false);
 
     // Hooks
     const $q = useQuasar();
@@ -63,6 +91,7 @@ export default {
 
       ndef.onreading = event => {
         console.log('NFC read event:', event);
+        isTransferring.value(true);
       };
 
       ndef.onreadingerror = event => {
@@ -144,6 +173,7 @@ export default {
         }
       } finally {
         cancelWrite();
+        isTransferring.value = false;
       }
     }
 
@@ -152,6 +182,7 @@ export default {
       isSharing,
       writeNfc,
       cancelWrite,
+      isTransferring
     };
   }
 };


### PR DESCRIPTION
#### _Resolves - informs user when data transfer begins_

---

### What kind of change does this PR introduce?

- Feature update.

<br/>

### What is the current behavior?

- User is not made aware of NFC transferring credential state.

<br/>

### What is the new behavior?

- When data begins to transfer, loading indicator and message appear.

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally ran, not tested with an actual NFC transfer - requires two android phones.

<br/>

### Screenshots: n/a