### PR TITLE
Fix call to dynamically add routes to Vue router.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-wallet ChangeLog
 
+## 29.3.2 - 2024-10-dd
+
+### Fixed
+- Fix call to dynamically add routes to Vue router.
+
 ## 29.3.1 - 2024-10-11
 
 ### Fixed

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as brQuasar from '@bedrock/quasar';
 import {config} from '@bedrock/web';
@@ -177,7 +177,7 @@ export async function configureRouter({
   }
   // add routes
   for(const route of routes) {
-    router.addRoute(route.name, route);
+    router.addRoute(route);
   }
 
   // handle behavior triggered by route changes


### PR DESCRIPTION
- The first parameter in `addRoute` is for a parent route or name of a parent route -- it should not have been passed when adding non-child routes.