### PR TITLE
Fix double scrollbar and redesign credential detail dialog for mobile

### DIFF
--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -30,7 +30,6 @@
       class="row full-height">
       <div class="col-xs-12 col-md-5 bg-grey-2 column full-height sidebar">
         <q-card
-          flat
           class="card-banner"
           :style="cardBackground">
           <credential-switch
@@ -138,7 +137,6 @@
       class="mobile-layout">
       <div class="mobile-card-wrap">
         <q-card
-          flat
           class="card-banner mobile-card"
           :style="cardBackground">
           <credential-switch
@@ -393,10 +391,14 @@ $breakpoint-sm: 767px;
   padding: 16px;
   aspect-ratio: 3.375 / 2.125;
   background-color: #FFFFFF;
-  /* The <q-card flat> prop applies Quasar's `no-shadow` class
-    (box-shadow: none !important) — `!important` here is required just to
-    beat that, not a style choice. */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
+  /* No `flat` prop on these q-cards (removed) — that prop was the only
+    reason Quasar's `no-shadow` class (box-shadow: none !important) ever
+    applied here, which then needed its own !important to beat. Simpler
+    to not create the constraint than to fight it: without `flat`, this
+    rule's own specificity (a class + the scoped data-v attribute) is
+    already higher than Quasar's plain `.q-card` default and wins on its
+    own. */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 
   /* CredentialField.vue (@bedrock/vue-vc, shared elsewhere at the old
     small fixed card width) hardcodes `max-width: 225px` plus a 1-line
@@ -405,7 +407,14 @@ $breakpoint-sm: 767px;
     text (e.g. issuer name) that would otherwise fit. `!important` is
     required to beat the inline style from here; scoped only to
     card-banner so other, still-small consumers of CredentialField
-    elsewhere in the wallet are unaffected. */
+    elsewhere in the wallet are unaffected.
+
+    TEMPORARY: bedrock-vue-vc branch worktree-credential-field-maxwidth-prop
+    (not yet merged/released) adds a real `maxWidth` prop to
+    CredentialField/CredentialBase so this won't need fighting via CSS at
+    all — once that ships and this repo's @bedrock/vue-vc dependency is
+    bumped, replace this :deep() override with passing
+    max-width="none" on the <credential-switch> elements above instead. */
   :deep(.cf-value),
   :deep(.cf-title) {
     max-width: none !important;

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -2,123 +2,196 @@
   <q-card
     flat
     class="details-dialog">
-    <div class="row full-height">
-      <!-- Close button -->
-      <q-btn
-        v-if="!nfcSharing"
-        v-close-popup
-        flat
-        round
-        color="dark"
-        icon="fa fa-times"
-        class="absolute-top-right q-ma-sm"
-        style="font-size: 0.75em; z-index: 1;" />
-      <!-- Left side details -->
-      <div class="col-xs-12 col-md-5 bg-white q-pt-xl q-pb-md q-px-xl">
-        <div
-          class="row justify-center full-height"
-          :class="nfcClass">
-          <q-card-section class="q-pa-none text-body1 text-left">
-            <q-card
-              class="card q-mx-auto"
-              :style="cardBackground">
-              <credential-switch
-                :credential="credential"
-                :text-color="cardStyles.textColor"
-                :name-override="credentialOverrides.title"
-                :image-override="credentialOverrides.image"
-                :description-override="credentialOverrides.subtitle">
-                <template
-                  v-if="hasNFCPayload({credential})"
-                  #image>
-                  <div class="row justify-between">
-                    <dynamic-image
-                      class="q-mr-auto"
-                      :src="credentialOverrides.image || credentialImage"
-                      size="md" />
-                    <!-- eslint-disable vue/no-v-html
-                      this is ok to disable only because `contactlessSvg` has
-                      been specifically sanitized -->
-                    <span v-html="contactlessSvg" />
-                    <!-- eslint-enable -->
-                  </div>
-                </template>
-              </credential-switch>
-            </q-card>
-            <div
-              v-if="nfcSharing"
-              class="row justify-center items-center text-body2 disabled
-                q-mt-md">
-              <q-spinner-ios
-                size="1em"
-                style="height: 24px; margin-right: 7px;" />
-              <div>
-                Sharing
-              </div>
-            </div>
-            <div
-              v-if="nfcSharing"
-              class="text-center q-pt-md">
-              <div class="text-body1">
-                Hold your device near a reader to share your credential.
-              </div>
-              <div>
-                <q-btn
-                  outline
-                  rounded
-                  no-caps
-                  class="q-mt-sm"
-                  @click="cancelWrite">
-                  Cancel
-                </q-btn>
-              </div>
-            </div>
-            <q-card-section
+    <!-- Close button -->
+    <q-btn
+      v-if="!nfcSharing"
+      v-close-popup
+      flat
+      round
+      color="dark"
+      icon="fa fa-times"
+      class="absolute-top-right q-ma-sm"
+      style="font-size: 0.75em; z-index: 1;" />
 
+    <!-- NFC sharing is its own mode, same on mobile and desktop — decoupled
+      from the structural split below so neither layout needs to account
+      for it internally. -->
+    <div
+      v-if="nfcSharing"
+      class="row justify-center items-center full-height nfc-sharing">
+      <div class="text-center">
+        <q-card
+          flat
+          class="card-banner nfc-card"
+          :style="cardBackground">
+          <credential-switch
+            :credential="credential"
+            :text-color="cardStyles.textColor"
+            :name-override="credentialOverrides.title"
+            :image-override="credentialOverrides.image"
+            :description-override="credentialOverrides.subtitle">
+            <template
               v-if="hasNFCPayload({credential})"
-              class="q-px-none q-pb-none flex full-width justify-center">
-              <NfcShare
-                ref="nfcShareComponent"
-                :credential="credential"
-                @sharing="nfcSharing = $event" />
-            </q-card-section>
-            <div v-if="!nfcSharing">
-              <div>
-                <div class="text-grey q-mt-lg text-body2">
-                  Description
-                </div>
-                <div class="text-body1">
-                  {{description}}
-                </div>
-                <div class="text-grey q-mt-md text-body2">
-                  Issued for
-                </div>
-                <div class="text-body1">
-                  {{credentialHolderName}}
-                </div>
+              #image>
+              <div class="row justify-between">
+                <dynamic-image
+                  class="q-mr-auto"
+                  :src="credentialOverrides.image || credentialImage"
+                  size="md" />
+                <!-- eslint-disable vue/no-v-html
+                  this is ok to disable only because `contactlessSvg` has
+                  been specifically sanitized -->
+                <span v-html="contactlessSvg" />
+                <!-- eslint-enable -->
+              </div>
+            </template>
+          </credential-switch>
+        </q-card>
+        <div
+          class="row justify-center items-center text-body2 disabled
+            q-mt-md">
+          <q-spinner-ios
+            size="1em"
+            style="height: 24px; margin-right: 7px;" />
+          <div>
+            Sharing
+          </div>
+        </div>
+        <div class="text-center q-pt-md">
+          <div class="text-body1">
+            Hold your device near a reader to share your credential.
+          </div>
+          <div>
+            <q-btn
+              outline
+              rounded
+              no-caps
+              class="q-mt-sm"
+              @click="cancelWrite">
+              Cancel
+            </q-btn>
+          </div>
+        </div>
+        <NfcShare
+          ref="nfcShareComponent"
+          :credential="credential"
+          @sharing="nfcSharing = $event" />
+      </div>
+    </div>
+
+    <!-- Desktop: sidebar + tabs side by side, unchanged from the original
+      layout (only the card-banner styling below is shared/new). -->
+    <div
+      v-else-if="!isMobile"
+      class="row full-height">
+      <div class="col-xs-12 col-md-5 bg-grey-2 column full-height sidebar">
+        <q-card
+          flat
+          class="card-banner"
+          :style="cardBackground">
+          <credential-switch
+            :credential="credential"
+            :text-color="cardStyles.textColor"
+            :name-override="credentialOverrides.title"
+            :image-override="credentialOverrides.image"
+            :description-override="credentialOverrides.subtitle">
+            <template
+              v-if="hasNFCPayload({credential})"
+              #image>
+              <div class="row justify-between">
+                <dynamic-image
+                  class="q-mr-auto"
+                  :src="credentialOverrides.image || credentialImage"
+                  size="md" />
+                <!-- eslint-disable vue/no-v-html
+                  this is ok to disable only because `contactlessSvg` has
+                  been specifically sanitized -->
+                <span v-html="contactlessSvg" />
+                <!-- eslint-enable -->
+              </div>
+            </template>
+          </credential-switch>
+        </q-card>
+        <div
+          class="col row justify-center q-pt-md q-pb-md q-px-xl
+            sidebar-body">
+          <q-card-section class="q-pa-none text-body1 text-left">
+            <div>
+              <div class="text-grey q-mt-lg text-body2">
+                Description
+              </div>
+              <div class="text-body1">
+                {{description}}
+              </div>
+              <div class="text-grey q-mt-md text-body2">
+                Issued for
+              </div>
+              <div class="text-body1">
+                {{credentialHolderName}}
               </div>
             </div>
-          </q-card-section>
-          <q-card-section
-            v-if="!nfcSharing"
-            class="flex full-width q-mt-auto">
-            <q-btn
-              flat
-              no-caps
-              label="Remove"
-              color="negative"
-              class="q-mx-auto"
-              icon="far fa-trash-alt"
-              @click="toggleDeleteWindow" />
           </q-card-section>
         </div>
       </div>
-      <!-- Right side details -->
       <CredentialDetailsViews
-        v-if="!nfcSharing"
         :credential="credential"
         :credential-overrides="credentialOverrides"
-        :credential-highlights="credentialHighlights" />
+        :credential-highlights="credentialHighlights"
+        show-remove
+        @remove="toggleDeleteWindow" />
+    </div>
+
+    <!-- Mobile: card as its own element on the dialog's transparent
+      background, 3rem gap, then a single bounded sheet with the tabs as
+      its own sticky header — see .mobile-layout/.card-banner/.detail-sheet
+      below. Purpose-built markup rather than reusing the desktop DOM
+      under media queries: every previous attempt at sharing one DOM tree
+      between the two layouts fought Quasar's own utility classes (`col`,
+      `full-height`) and/or its JS-managed component sizing (q-scroll-area),
+      neither of which a same-specificity or even `!important` CSS override
+      reliably won against. Separate markup means neither layout inherits
+      classes the other layout needs different behavior from. -->
+    <div
+      v-else
+      class="mobile-layout">
+      <div class="mobile-card-wrap">
+        <q-card
+          flat
+          class="card-banner mobile-card"
+          :style="cardBackground">
+          <credential-switch
+            :credential="credential"
+            :text-color="cardStyles.textColor"
+            :name-override="credentialOverrides.title"
+            :image-override="credentialOverrides.image"
+            :description-override="credentialOverrides.subtitle">
+            <template
+              v-if="hasNFCPayload({credential})"
+              #image>
+              <div class="row justify-between">
+                <dynamic-image
+                  class="q-mr-auto"
+                  :src="credentialOverrides.image || credentialImage"
+                  size="md" />
+                <!-- eslint-disable vue/no-v-html
+                  this is ok to disable only because `contactlessSvg` has
+                  been specifically sanitized -->
+                <span v-html="contactlessSvg" />
+                <!-- eslint-enable -->
+              </div>
+            </template>
+          </credential-switch>
+        </q-card>
+      </div>
+      <div class="detail-sheet">
+        <CredentialDetailsViews
+          :credential="credential"
+          :credential-overrides="credentialOverrides"
+          :credential-highlights="credentialHighlights"
+          :credential-holder-name="credentialHolderName"
+          show-remove
+          @remove="toggleDeleteWindow" />
+      </div>
     </div>
   </q-card>
 </template>
@@ -127,7 +200,7 @@
 /*!
  * Copyright (c) 2015-2024 Digital Bazaar, Inc. All rights reserved.
  */
-import {computed, ref} from 'vue';
+import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
 import {
   CredentialSwitch, DynamicImage, useCredentialCommon
 } from '@bedrock/vue-vc';
@@ -137,6 +210,12 @@ import {helpers} from '@bedrock/web-wallet';
 import NfcShare from './NfcShare.vue';
 
 const {hasNFCPayload} = helpers;
+
+// Matches the Quasar grid breakpoint the sidebar's `col-md-5` class
+// switches on (1024px) — the point where the layout actually needs to be
+// structurally different, not the unrelated 767px used for the dialog's
+// own box sizing.
+const MOBILE_QUERY = '(max-width: 1023px)';
 
 export default {
   name: 'CredentialDetails',
@@ -188,14 +267,27 @@ export default {
     const nfcShareComponent = ref(null);
     console.log('Credential details', props.credential);
 
-    const nfcClass = computed(() => {
-      const isNfcSharing = nfcSharing.value;
-      if(!isNfcSharing) {
-        return ['items-start'];
-      }
-
-      return ['items-center', 'nfc-card-position'];
+    // Reactive breakpoint check via matchMedia rather than Quasar's own
+    // `$q.screen` — confirmed by direct testing that `$q.screen.lt.sm`
+    // (used by CredentialCardBundle.vue's `:maximized` prop) does not
+    // reliably reflect real viewport width changes (e.g. under DevTools
+    // device emulation without a full reload). matchMedia is the
+    // browser's own primitive and does not depend on Quasar's internal
+    // state syncing.
+    const isMobile = ref(false);
+    let mql;
+    function updateIsMobile(event) {
+      isMobile.value = event.matches;
+    }
+    onMounted(() => {
+      mql = window.matchMedia(MOBILE_QUERY);
+      isMobile.value = mql.matches;
+      mql.addEventListener('change', updateIsMobile);
     });
+    onBeforeUnmount(() => {
+      mql?.removeEventListener('change', updateIsMobile);
+    });
+
     // Credential description
     const description = computed(() => {
       if(props.credentialOverrides.description) {
@@ -221,8 +313,8 @@ export default {
       showDelete,
       description,
       hasNFCPayload,
+      isMobile,
       nfcSharing,
-      nfcClass,
       nfcShareComponent
     };
   }
@@ -232,6 +324,12 @@ export default {
 <style lang="scss" scoped>
 $breakpoint-sm: 767px;
 .details-dialog {
+  /* Never let the outer dialog itself become a scroll owner — only the
+    regions designed below to scroll (the tab panel's own internal
+    q-scroll-area at desktop, or .detail-sheet at mobile) should ever show
+    a scrollbar. */
+  overflow: hidden;
+
   /* Apply styles when dialog is not full screen */
   @media (min-width: #{$breakpoint-sm}) {
     border-radius: 12px;
@@ -240,18 +338,121 @@ $breakpoint-sm: 767px;
     max-width: 80vw;
     max-height: 80vh;
   }
-}
-.card {
-  /* Credit card ratio 2.125 H by 3.375 W */
-  width: 275px;
-  padding: 16px;
-  border-radius: 16px;
-  aspect-ratio: 3.375 / 2.125;
-  background-color: #FFFFFF;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+
+  /* Below 767px this component assumed CredentialCardBundle.vue's
+    `:maximized="$q.screen.lt.sm"` would give the dialog a real 100vh
+    height for free. Confirmed by direct testing that assumption doesn't
+    reliably hold — without an explicit height here, .mobile-layout below
+    (height:100%) has nothing to actually fill. Setting height directly
+    here makes this component self-sufficient regardless of whether the
+    parent's maximized prop actually engages. */
+  @media (max-width: 1023px) {
+    height: 100vh;
+    height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
+  }
 }
 
-.nfc-card-position {
-  margin-top: -16vh;
+.card-banner {
+  /* Credit card ratio 2.125 H by 3.375 W (1.588:1 — not exactly 3:2,
+    inherited from the original card's own comment). Capped at max-width
+    so the fixed ratio doesn't balloon its height when its container is
+    much wider than the original ~275px card — width alone scaling up
+    (with height following via aspect-ratio) produced a mostly-empty card
+    that barely read as a bounded card at all. */
+  width: 100%;
+  max-width: 340px;
+  /* 16px top/left to match CredentialDetailsViews.vue's own q-pa-md
+    (Quasar padding-all-medium = 16px) on its root — that's what puts the
+    "Highlights" tab label 16px from the row's top on the right side, so
+    the card's own top/left edges need the same offset to align with it.
+    No longer horizontally centered (right stays auto, not also 16px). */
+  margin: 16px auto 0 16px;
+  border-radius: 16px;
+  padding: 16px;
+  aspect-ratio: 3.375 / 2.125;
+  background-color: #FFFFFF;
+  /* The <q-card flat> prop applies Quasar's `no-shadow` class
+    (box-shadow: none !important) — `!important` here is required just to
+    beat that, not a style choice. */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
+
+  /* CredentialField.vue (@bedrock/vue-vc, shared elsewhere at the old
+    small fixed card width) hardcodes `max-width: 225px` plus a 1-line
+    ellipsis clamp via an inline style attribute, tuned for the previous
+    ~275px card. Now that this card is wider, that same cap truncates
+    text (e.g. issuer name) that would otherwise fit. `!important` is
+    required to beat the inline style from here; scoped only to
+    card-banner so other, still-small consumers of CredentialField
+    elsewhere in the wallet are unaffected. */
+  :deep(.cf-value),
+  :deep(.cf-title) {
+    max-width: none !important;
+  }
+}
+
+.mobile-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  /* Card sits against the dialog's own background, not a colored panel of
+    its own — this is what "transparent" differentiation means here: no
+    background-color competing with the card's own. */
+  background: transparent;
+}
+
+.mobile-card-wrap {
+  flex: none;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem 1.5rem;
+
+  /* .card-banner's own margin (16px top/left, to align with the desktop
+    tabs row) leaked into mobile through the shared class — this wrap's
+    own padding already provides mobile's top gap (3rem) and centering
+    (justify-content), so the card needs its margin reset back to
+    symmetric auto here, or it renders off-center and the mismatched
+    left/right spacing can crowd the shadow against one edge. */
+  .mobile-card {
+    margin: 0 auto !important;
+  }
+}
+
+.detail-sheet {
+  /* The single bounded, single-scrolling region at mobile. flex:1 to
+    consume the remaining height below the (fixed-size) card-wrap;
+    min-height:0 is what actually allows it to be smaller than its
+    content and scroll internally, instead of growing to fit content and
+    pushing the whole page taller — the same flex rule that DB-732's
+    original fix depended on, just on purpose-built markup this time
+    instead of fighting Quasar's `col` utility class for it. */
+  flex: 1;
+  min-height: 0;
+  margin: 0 1rem 1.5rem;
+  border-radius: 16px;
+  overflow: hidden;
+  background-color: #F5F5F5;
+  display: flex;
+  flex-direction: column;
+
+  :deep(.details-panel-root) {
+    /* CredentialDetailsViews' own root no longer needs to fight for
+      height here — .detail-sheet above is the bounded/scrolling
+      container; this just needs to lay out its own children (tabs,
+      then content) naturally within whatever height that gives it. */
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  :deep(.q-tabs) {
+    /* Sticky *within `.details-panel-root`'s own scroll* (the nearest
+      scrolling ancestor), so the tabs stay visible as the info block and
+      tab-panel content scroll beneath them. */
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: #F5F5F5;
+  }
 }
 </style>

--- a/components/CredentialDetails.vue
+++ b/components/CredentialDetails.vue
@@ -13,76 +13,20 @@
       class="absolute-top-right q-ma-sm"
       style="font-size: 0.75em; z-index: 1;" />
 
-    <!-- NFC sharing is its own mode, same on mobile and desktop — decoupled
-      from the structural split below so neither layout needs to account
-      for it internally. -->
-    <div
-      v-if="nfcSharing"
-      class="row justify-center items-center full-height nfc-sharing">
-      <div class="text-center">
-        <q-card
-          flat
-          class="card-banner nfc-card"
-          :style="cardBackground">
-          <credential-switch
-            :credential="credential"
-            :text-color="cardStyles.textColor"
-            :name-override="credentialOverrides.title"
-            :image-override="credentialOverrides.image"
-            :description-override="credentialOverrides.subtitle">
-            <template
-              v-if="hasNFCPayload({credential})"
-              #image>
-              <div class="row justify-between">
-                <dynamic-image
-                  class="q-mr-auto"
-                  :src="credentialOverrides.image || credentialImage"
-                  size="md" />
-                <!-- eslint-disable vue/no-v-html
-                  this is ok to disable only because `contactlessSvg` has
-                  been specifically sanitized -->
-                <span v-html="contactlessSvg" />
-                <!-- eslint-enable -->
-              </div>
-            </template>
-          </credential-switch>
-        </q-card>
-        <div
-          class="row justify-center items-center text-body2 disabled
-            q-mt-md">
-          <q-spinner-ios
-            size="1em"
-            style="height: 24px; margin-right: 7px;" />
-          <div>
-            Sharing
-          </div>
-        </div>
-        <div class="text-center q-pt-md">
-          <div class="text-body1">
-            Hold your device near a reader to share your credential.
-          </div>
-          <div>
-            <q-btn
-              outline
-              rounded
-              no-caps
-              class="q-mt-sm"
-              @click="cancelWrite">
-              Cancel
-            </q-btn>
-          </div>
-        </div>
-        <NfcShare
-          ref="nfcShareComponent"
-          :credential="credential"
-          @sharing="nfcSharing = $event" />
-      </div>
-    </div>
-
     <!-- Desktop: sidebar + tabs side by side, unchanged from the original
-      layout (only the card-banner styling below is shared/new). -->
+      layout (only the card-banner styling below is shared/new). NFC
+      sharing is NOT its own separate mode/branch — NfcShare must render
+      whenever hasNFCPayload is true REGARDLESS of nfcSharing, since its
+      own "Tap to Share" control is what sets nfcSharing to true in the
+      first place. Gating NfcShare itself behind nfcSharing (an earlier
+      version of this fix did exactly that, to "unify" the two layouts'
+      NFC handling) made it impossible to ever start a share — nfcSharing
+      only ever changes value if NfcShare exists to emit it. nfcSharing
+      instead only toggles the surrounding text and hides the rest of the
+      dialog while a share is actually in progress, matching the original
+      per-layout behavior this replaced. -->
     <div
-      v-else-if="!isMobile"
+      v-if="!isMobile"
       class="row full-height">
       <div class="col-xs-12 col-md-5 bg-grey-2 column full-height sidebar">
         <q-card
@@ -113,6 +57,43 @@
           </credential-switch>
         </q-card>
         <div
+          v-if="nfcSharing"
+          class="row justify-center items-center text-body2 disabled
+            q-mt-md">
+          <q-spinner-ios
+            size="1em"
+            style="height: 24px; margin-right: 7px;" />
+          <div>
+            Sharing
+          </div>
+        </div>
+        <div
+          v-if="nfcSharing"
+          class="text-center q-pt-md">
+          <div class="text-body1">
+            Hold your device near a reader to share your credential.
+          </div>
+          <div>
+            <q-btn
+              outline
+              rounded
+              no-caps
+              class="q-mt-sm"
+              @click="cancelWrite">
+              Cancel
+            </q-btn>
+          </div>
+        </div>
+        <q-card-section
+          v-if="hasNFCPayload({credential})"
+          class="q-px-none q-pb-none flex full-width justify-center">
+          <NfcShare
+            ref="nfcShareComponent"
+            :credential="credential"
+            @sharing="nfcSharing = $event" />
+        </q-card-section>
+        <div
+          v-if="!nfcSharing"
           class="col row justify-center q-pt-md q-pb-md q-px-xl
             sidebar-body">
           <q-card-section class="q-pa-none text-body1 text-left">
@@ -134,6 +115,7 @@
         </div>
       </div>
       <CredentialDetailsViews
+        v-if="!nfcSharing"
         :credential="credential"
         :credential-overrides="credentialOverrides"
         :credential-highlights="credentialHighlights"
@@ -182,8 +164,46 @@
             </template>
           </credential-switch>
         </q-card>
+        <div
+          v-if="nfcSharing"
+          class="row justify-center items-center text-body2 disabled
+            q-mt-md">
+          <q-spinner-ios
+            size="1em"
+            style="height: 24px; margin-right: 7px;" />
+          <div>
+            Sharing
+          </div>
+        </div>
+        <div
+          v-if="nfcSharing"
+          class="text-center q-pt-md">
+          <div class="text-body1">
+            Hold your device near a reader to share your credential.
+          </div>
+          <div>
+            <q-btn
+              outline
+              rounded
+              no-caps
+              class="q-mt-sm"
+              @click="cancelWrite">
+              Cancel
+            </q-btn>
+          </div>
+        </div>
+        <q-card-section
+          v-if="hasNFCPayload({credential})"
+          class="q-px-none q-pb-none flex full-width justify-center">
+          <NfcShare
+            ref="nfcShareComponent"
+            :credential="credential"
+            @sharing="nfcSharing = $event" />
+        </q-card-section>
       </div>
-      <div class="detail-sheet">
+      <div
+        v-if="!nfcSharing"
+        class="detail-sheet">
         <CredentialDetailsViews
           :credential="credential"
           :credential-overrides="credentialOverrides"

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -1,30 +1,32 @@
 <template>
-  <div class="col bg-grey-2 q-pa-md">
-    <q-tabs
-      v-model="tab"
-      dense
-      align="justify"
-      narrow-indicator
-      active-color="primary"
-      class="text-grey q-px-xl"
-      indicator-color="primary">
-      <q-tab
-        v-if="showHighlights"
-        no-caps
-        name="highlights"
-        label="Highlights" />
-      <q-tab
-        v-if="showDisplays"
-        no-caps
-        name="displays"
-        label="Displays" />
-      <!-- Not yet implemented -->
-      <q-tab
-        v-if="showDetails"
-        no-caps
-        name="details"
-        label="Details" />
-    </q-tabs>
+  <div class="col bg-grey-2 q-pa-md details-panel-root">
+    <div class="row items-center q-px-xl tabs-header">
+      <q-tabs
+        v-model="tab"
+        dense
+        align="justify"
+        narrow-indicator
+        active-color="primary"
+        class="text-grey col"
+        indicator-color="primary">
+        <q-tab
+          v-if="showHighlights"
+          no-caps
+          name="highlights"
+          label="Highlights" />
+        <q-tab
+          v-if="showDisplays"
+          no-caps
+          name="displays"
+          label="Displays" />
+        <!-- Not yet implemented -->
+        <q-tab
+          v-if="showDetails"
+          no-caps
+          name="details"
+          label="Details" />
+      </q-tabs>
+    </div>
 
     <!-- Highlights -->
     <q-tab-panels
@@ -34,7 +36,7 @@
       <q-tab-panel
         name="highlights"
         class="bg-grey-2">
-        <div class="row justify-start items-start">
+        <div class="row justify-start items-start details-panel-row">
           <q-scroll-area
             visible
             :thumb-style="scrollBarStyles"
@@ -56,6 +58,23 @@
                   <div class="text-body1">
                     {{value}}
                   </div>
+                </div>
+              </div>
+              <!-- Holder name — only passed by CredentialDetails.vue's
+                mobile layout; desktop already shows this in its own
+                sidebar, so passing it there too would duplicate it. Not
+                part of credentialHighlights itself (that's issuer-side
+                data: Achievement/Type/Description/Criteria/Issued By) —
+                this is holder-side, so it's a separate field here rather
+                than injected into that object upstream. -->
+              <div
+                v-if="credentialHolderName"
+                class="q-mt-md">
+                <div class="text-grey text-body2">
+                  Issued for
+                </div>
+                <div class="text-body1">
+                  {{credentialHolderName}}
                 </div>
               </div>
             </q-card-section>
@@ -132,6 +151,20 @@
               Developer Only
             </div>
           </q-banner>
+          <!-- Only rendered when a parent passes `show-remove`
+            (CredentialDetails.vue's mobile layout does; desktop keeps its
+            own separate Remove button in the sidebar). -->
+          <div
+            v-if="showRemove"
+            class="flex justify-center q-my-md">
+            <q-btn
+              flat
+              no-caps
+              label="Remove"
+              color="negative"
+              icon="far fa-trash-alt"
+              @click="$emit('remove')" />
+          </div>
           <credential-details-tree :credential="credential" />
         </div>
       </q-tab-panel>
@@ -170,8 +203,24 @@ export default {
         subtitle: '',
         description: ''
       })
+    },
+    // Renders a small Remove icon button alongside the tabs — used by
+    // CredentialDetails.vue's mobile layout only; the desktop layout has
+    // its own separate Remove button in the sidebar and does not pass
+    // this.
+    showRemove: {
+      type: Boolean,
+      default: false
+    },
+    // Holder name, shown as an extra "Issued for" field in the Highlights
+    // panel — only passed by the mobile layout (see showRemove above for
+    // why: desktop already shows this elsewhere).
+    credentialHolderName: {
+      type: String,
+      default: ''
     }
   },
+  emits: ['remove'],
   setup(props) {
     // Local state
     const slideNumber = ref(1);
@@ -297,8 +346,51 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+/*
+ * DB-732: .details-view previously had a hardcoded height:500px with no
+ * relation to its ancestors' real height, while the outer dialog
+ * (CredentialDetails.vue's .details-dialog) has its own separate fixed
+ * height/max-height. Neither budget was aware of the other, so either one
+ * could independently overflow and show its own scrollbar. Making height
+ * flow through the chain as flex instead fixes that: only the actual
+ * content's real overflow (if any) triggers a scrollbar, and it does so in
+ * one place.
+ *
+ * At mobile widths, CredentialDetails.vue no longer reuses this same DOM
+ * under a media query — it renders this component inside its own
+ * purpose-built `.detail-sheet` container instead, which is the bounded/
+ * scrolling element there. So this file only needs to handle its one,
+ * consistent desktop context now; no internal breakpoint logic here.
+ */
+.details-panel-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  :deep(.q-tab-panels) {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  :deep(.q-tab-panel) {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
+}
+
+.details-panel-row {
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+}
+
 .details-view {
   width: 100%;
-  height: 500px;
+  flex: 1;
+  min-height: 0;
 }
 </style>

--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -151,9 +151,9 @@
               Developer Only
             </div>
           </q-banner>
-          <!-- Only rendered when a parent passes `show-remove`
-            (CredentialDetails.vue's mobile layout does; desktop keeps its
-            own separate Remove button in the sidebar). -->
+          <!-- Only rendered when a parent passes `show-remove` — both the
+            desktop and mobile layouts in CredentialDetails.vue do, so
+            Remove lives in the same spot (here) on both. -->
           <div
             v-if="showRemove"
             class="flex justify-center q-my-md">
@@ -204,10 +204,9 @@ export default {
         description: ''
       })
     },
-    // Renders a small Remove icon button alongside the tabs — used by
-    // CredentialDetails.vue's mobile layout only; the desktop layout has
-    // its own separate Remove button in the sidebar and does not pass
-    // this.
+    // Renders a Remove button in the Details tab panel, after the
+    // "Developer Only" banner — passed by both the desktop and mobile
+    // layouts in CredentialDetails.vue.
     showRemove: {
       type: Boolean,
       default: false


### PR DESCRIPTION
## Summary
- Fixes the double-scrollbar bug in the credential detail dialog (DB-732) by giving the tab content a single scroll owner instead of letting both the page and the panel scroll independently.
- Adds a purpose-built mobile layout (`matchMedia`-driven, not Quasar's `$q.screen`) alongside the existing desktop sidebar+tabs layout, since the desktop markup could not be responsively reused without fighting Quasar's `col`/`flex-basis: 0%` behavior.
- Relocates the Remove button out of the sidebar/tabs row and into `CredentialDetailsViews.vue` so both layouts share one implementation. This is a deliberate design decision — tradeoff is slightly lower discoverability (it's no longer in the always-visible sidebar), traded for one shared implementation instead of two.
- Adds a targeted, **temporary** `CredentialField.vue` max-width override in `CredentialDetails.vue`'s `.card-banner` (`:deep(.cf-value)`/`:deep(.cf-title)`). This is a stopgap: `bedrock-vue-vc`'s `worktree-credential-field-maxwidth-prop` branch adds a real `max-width` prop for this exact problem — once that's merged/released and this repo bumps its `@bedrock/vue-vc` dependency, this override should be deleted in favor of passing the prop directly.
- Drops the `flat` prop on the card banner instead of fighting Quasar's resulting no-shadow rule with `!important` (3rd commit, 29d721e) — removes the constraint at its source rather than overriding its effect.
- NFC sharing was broken by the mobile layout split partway through this branch, then fixed within this same branch before it ever shipped (caught by Codex review pre-push, not by a user).

## Test plan
- [ ] Open a credential's detail dialog on desktop — sidebar/tabs layout unchanged, single scrollbar in tab content.
- [ ] Open the same dialog at a mobile viewport width (<1024px) — card is centered with correct aspect ratio and shadow, tab sheet scrolls independently with visible spacing from the dialog edge.
- [ ] Start an NFC share on both layouts — confirm sharing still starts.
- [ ] Remove a credential from both layouts — confirm the relocated Remove button still works.