### PR TITLE
Add HTML Render Method support to the credential Displays tab

### DIFF
--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -69,7 +69,7 @@
         class="bg-grey-2 q-px-none text-center">
         <div class="details-view">
           <q-spinner
-            v-if="showDisplays && !credentialImages.length"
+            v-if="showDisplays && !displays.length"
             size="48px"
             color="primary"
             style="margin-top: 90px" />
@@ -88,17 +88,23 @@
             class="bg-grey-2 q-mb-none fit"
             navigation-icon="far fa-circle">
             <q-carousel-slide
-              v-for="(image, index) in credentialImages"
-              :key="image"
+              v-for="(display, index) in displays"
+              :key="index"
               :name="index + 1"
               class="q-pa-none">
               <q-scroll-area class="fit bg-grey-2">
                 <div class="flex">
                   <q-img
-                    :src="image"
+                    v-if="display.kind === 'image'"
+                    :src="display.content"
                     spinner-color="primary"
                     class="q-mx-auto rounded-borders"
                     style="max-width: 100%; pointer-events: none;" />
+                  <credential-html-display
+                    v-else-if="display.kind === 'html'"
+                    :credential="credential"
+                    :render-method="display.renderMethod"
+                    class="full-width" />
                 </div>
               </q-scroll-area>
             </q-carousel-slide>
@@ -145,6 +151,7 @@
  */
 import {onBeforeMount, onMounted, reactive, ref} from 'vue';
 import CredentialDetailsTree from './CredentialDetailsTree.vue';
+import CredentialHtmlDisplay from './CredentialHtmlDisplay.vue';
 import {date} from 'quasar';
 import Mustache from 'mustache';
 
@@ -152,7 +159,7 @@ const {formatDate} = date;
 
 export default {
   name: 'CredentialDetailsViews',
-  components: {CredentialDetailsTree},
+  components: {CredentialDetailsTree, CredentialHtmlDisplay},
   props: {
     credential: {
       type: Object,
@@ -180,7 +187,9 @@ export default {
     const showDetails = ref(true);
     const showDisplays = ref(false);
     const showHighlights = ref(false);
-    const credentialImages = reactive([]);
+    // unified display list
+    // {kind: 'image', content} | {kind: 'html', renderMethod}
+    const displays = reactive([]);
 
     // Select initial tab
     onMounted(() => {
@@ -192,11 +201,6 @@ export default {
         tab.value = 'displays';
       }
     });
-
-    // Constants
-    const supportedRenderMethods = [
-      'SvgRenderingTemplate2023', 'SvgRenderingTemplate2024'
-    ];
 
     // Scroll area bar style
     const scrollBarStyles = {
@@ -216,14 +220,15 @@ export default {
     async function getDisplaysFromRenderMethod() {
       if(props.credential?.renderMethod?.length) {
         props.credential.renderMethod.forEach(async rm => {
-          if(supportedRenderMethods.includes(rm.type)) {
-            if(rm.type === 'SvgRenderingTemplate2023') {
-              useRenderTemplate2023(rm.id);
-            } else if(rm.type === 'SvgRenderingTemplate2024') {
-              const {template, url} = rm;
-              const values = props.credential;
-              await useRenderTemplate2024(template, url, values);
-            }
+          if(rm.type === 'SvgRenderingTemplate2023') {
+            useRenderTemplate2023(rm.id);
+          } else if(rm.type === 'SvgRenderingTemplate2024') {
+            const {template, url} = rm;
+            const values = props.credential;
+            await useRenderTemplate2024(template, url, values);
+          } else if(rm.type === 'TemplateRenderMethod' &&
+            rm.renderSuite === 'html') {
+            useHtmlRenderMethod(rm);
           }
         });
       }
@@ -235,7 +240,7 @@ export default {
      * @param {string} srcValue - Data URI.
      */
     function useRenderTemplate2023(srcValue) {
-      credentialImages.push(srcValue);
+      displays.push({kind: 'image', content: srcValue});
     }
 
     /*
@@ -279,7 +284,13 @@ export default {
 
       const rv = Mustache.render(template, {...values, ...formattingFunctions});
       const image = `data:image/svg+xml;base64,${btoa(rv)}`;
-      credentialImages.push(image);
+      displays.push({kind: 'image', content: image});
+    }
+
+    // Adds an HTML render method to the displays list; the sandboxed render
+    // is performed by the CredentialHtmlDisplay component.
+    function useHtmlRenderMethod(renderMethod) {
+      displays.push({kind: 'html', renderMethod});
     }
 
     return {
@@ -290,7 +301,7 @@ export default {
       showDisplays,
       showHighlights,
       scrollBarStyles,
-      credentialImages
+      displays
     };
   }
 };

--- a/components/CredentialHtmlDisplay.vue
+++ b/components/CredentialHtmlDisplay.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="credential-html-display">
+    <q-spinner
+      v-if="loading"
+      size="48px"
+      color="primary"
+      style="margin-top: 90px" />
+    <q-banner
+      v-if="error"
+      dense
+      rounded
+      class="bg-red-5 text-white q-ma-md">
+      {{error}}
+    </q-banner>
+    <div
+      ref="mount"
+      class="html-render-mount" />
+  </div>
+</template>
+
+<script>
+/*!
+ * Copyright (c) 2026 Digital Bazaar, Inc.
+ */
+import {onMounted, onUnmounted, ref} from 'vue';
+import {HtmlRenderer} from '@digitalbazaar/vc-html-render-method';
+
+export default {
+  name: 'CredentialHtmlDisplay',
+  props: {
+    credential: {
+      type: Object,
+      required: true
+    },
+    // the specific HTML render method to render; if omitted, the library
+    // renders the first HTML render method found on the credential
+    renderMethod: {
+      type: Object,
+      default: undefined
+    }
+  },
+  setup(props) {
+    // Constants
+    let handle = null;
+
+    // Refs
+    const mount = ref(null);
+    const loading = ref(true);
+    const error = ref('');
+
+    // Lifecycle hooks
+    onMounted(async () => {
+      try {
+        // render the issuer template into a nested, sandboxed iframe; the
+        // library owns the host-frame CSP (`frame-src 'none'`) and selective
+        // disclosure, so nothing here weakens the wallet's own security
+        handle = new HtmlRenderer().render({
+          mount: mount.value,
+          credential: props.credential,
+          renderMethod: props.renderMethod
+        });
+
+        // relay the frame's auto-size up to the mount container so tall cards
+        // are not clipped inside the carousel/scroll area
+        handle.on('resize', payload => {
+          const height = payload?.height ?? payload?.detail?.height;
+          if(height && mount.value) {
+            mount.value.style.height = `${height}px`;
+          }
+        });
+
+        // resolves on `renderMethodReady()`; rejects on error/timeout
+        await handle.ready;
+      } catch(e) {
+        error.value = e?.message ?? 'Unable to render this credential.';
+      } finally {
+        loading.value = false;
+      }
+    });
+
+    onUnmounted(() => {
+      handle?.destroy();
+      handle = null;
+    });
+
+    return {mount, loading, error};
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.credential-html-display {
+  width: 100%;
+  text-align: center;
+}
+.html-render-mount {
+  width: 100%;
+}
+// the library appends the host iframe into the mount element
+.html-render-mount :deep(iframe) {
+  display: block;
+  width: 100%;
+  border: 0;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@digitalbazaar/http-client": "^4.1.1",
+    "@digitalbazaar/vc-html-render-method": "github:digitalbazaar/vc-html-render-method#initial-setup",
     "@digitalbazaar/web-app-manifest-utils": "^2.0.0",
     "html5-qrcode": "^2.3.8",
     "mustache": "^4.2.0",


### PR DESCRIPTION


- Add `CredentialHtmlDisplay.vue`: a thin component that mounts the
  `HtmlRenderer`, awaits `ready`, relays `resize` to size the mount, shows
  loading/error state, and destroys the handle on unmount.
- Wire it into `CredentialDetailsViews.vue`: replace the flat
  `credentialImages` array with a unified `displays` list
  (`{kind: 'image' | 'html'}`) and detect HTML via
  `type === 'TemplateRenderMethod' && renderSuite === 'html'`. Existing SVG
  rendering is unchanged; a credential that declares multiple render methods
  shows all of them as separate carousel slides.
- Add `@digitalbazaar/vc-html-render-method` as a dependency (temporarily
  pinned to the `initial-setup` branch until it is published to npm).
  
Addresses #143

---
Output | Preview in Wallet running locally

Note: Right hand side console displays some manual testing approach:

a) Template isolation — opaque origin, no ambient access (template frame)

```js
try { window.top.location.href; console.log('top: REACHED (FAIL)'); }
catch(e) { console.log('top: blocked', e.name); }
try { window.parent.document; console.log('parent: REACHED (FAIL)'); }
catch(e) { console.log('parent: blocked', e.name); }
console.log('origin:', document.location.origin);
```

b) No network egress (template frame)

```js
fetch('https://example.com')
  .then(() => console.log('fetch: ALLOWED (FAIL)'))
  .catch(e => console.log('fetch: blocked', e.message));
document.querySelector('meta[http-equiv="content-security-policy" i]')?.content;
```

c) Selective disclosure applied before render (template frame)

```js
JSON.parse(document.querySelector('script[name="credential"]').textContent);
```

d) `frame-src` 'none' blocks <iframe src> (host frame; .card → null)

```js
const f = document.createElement('iframe');
f.src = 'https://example.com';
document.body.appendChild(f);
```

<img width="1771" height="864" alt="Screenshot 2026-08-06 at 1 42 44 PM" src="https://github.com/user-attachments/assets/749192ca-1d15-455b-b3ed-82ee98c747fd" />

