### PR TITLE
Fix SVG template rendering in the Displays tab.

### DIFF
--- a/components/CredentialDetailsViews.vue
+++ b/components/CredentialDetailsViews.vue
@@ -218,29 +218,36 @@ export default {
 
     // Extract and parse images from credential's render method property
     async function getDisplaysFromRenderMethod() {
-      if(props.credential?.renderMethod?.length) {
-        props.credential.renderMethod.forEach(async rm => {
+      const renderMethods = props.credential?.renderMethod;
+      if(!renderMethods?.length) {
+        return;
+      }
+      // `forEach` does not await an async callback, so a fetched template
+      // could be pushed after a render method declared later; resolve them
+      // all first and push in the order the credential declares them
+      const resolved = await Promise.all(renderMethods.map(async rm => {
+        try {
           if(rm.type === 'SvgRenderingTemplate2023') {
-            useRenderTemplate2023(rm.id);
-          } else if(rm.type === 'SvgRenderingTemplate2024') {
+            // the id is itself the image
+            return rm.id ? {kind: 'image', content: rm.id} : null;
+          }
+          if(rm.type === 'SvgRenderingTemplate2024') {
             const {template, url} = rm;
             const values = props.credential;
-            await useRenderTemplate2024(template, url, values);
-          } else if(rm.type === 'TemplateRenderMethod' &&
-            rm.renderSuite === 'html') {
-            useHtmlRenderMethod(rm);
+            return await useRenderTemplate2024(template, url, values);
           }
-        });
-      }
-    }
-
-    /**
-     * Uses id for src value in image.
-     *
-     * @param {string} srcValue - Data URI.
-     */
-    function useRenderTemplate2023(srcValue) {
-      displays.push({kind: 'image', content: srcValue});
+          if(rm.type === 'TemplateRenderMethod' && rm.renderSuite === 'html') {
+            return {kind: 'html', renderMethod: rm};
+          }
+        } catch(e) {
+          // one template that cannot be fetched or rendered must not take the
+          // whole displays tab down with it
+          console.error(
+            'Failed to render credential render method', rm.type, e);
+        }
+        return null;
+      }));
+      displays.push(...resolved.filter(display => display !== null));
     }
 
     /*
@@ -263,6 +270,8 @@ export default {
      * @param {string} template - Svg.
      * @param {string} url - Url.
      * @param {object} values - Credential.credentialSubject.
+     *
+     * @returns {Promise<object>} An image display holding an SVG data URI.
      */
     async function useRenderTemplate2024(template, url, values) {
       // Example credential renderMethod property:
@@ -277,20 +286,30 @@ export default {
       //    }
       //  ]
       //
-      if(!template || url) {
-        const resp = await fetch(url);
+      // the inline template travels inside the signed credential and a fetched
+      // one does not, so an inline template wins when both are present
+      if(!template) {
+        if(typeof url !== 'string' || !/^https:\/\//.test(url)) {
+          // `fetch(undefined)` requested the wallet's own origin and rendered
+          // its markup as the credential's artwork
+          throw new Error(`Unusable render method template url "${url}".`);
+        }
+        const resp = await fetch(url, {credentials: 'omit'});
+        if(!resp.ok) {
+          // an error page would otherwise become the credential's artwork
+          throw new Error(
+            `Render method template fetch failed with ${resp.status}.`);
+        }
         template = await resp.text();
       }
 
       const rv = Mustache.render(template, {...values, ...formattingFunctions});
-      const image = `data:image/svg+xml;base64,${btoa(rv)}`;
-      displays.push({kind: 'image', content: image});
-    }
-
-    // Adds an HTML render method to the displays list; the sandboxed render
-    // is performed by the CredentialHtmlDisplay component.
-    function useHtmlRenderMethod(renderMethod) {
-      displays.push({kind: 'html', renderMethod});
+      // not `btoa`: it is Latin-1 only, so a credential holding any character
+      // above U+00FF (a name in Chinese, Japanese, Korean, Arabic...) threw
+      // and lost its artwork entirely
+      const image =
+        `data:image/svg+xml;charset=utf-8,${encodeURIComponent(rv)}`;
+      return {kind: 'image', content: image};
     }
 
     return {


### PR DESCRIPTION
Four faults in the SVG path this tab renders. Targeting this branch rather
than main so #144 lands with them fixed.

**`btoa` is Latin-1 only.** A credential holding any character above U+00FF — a name in Chinese, Japanese, Korean or Arabic — throws and loses its artwork. The throw escapes an async callback nothing awaits, so the tab stays on its spinner and no error reaches the console. Now encoded as a UTF-8 data URI.

**`if(!template || url)` fetches even when an inline template is present.** The inline template travels inside the signed credential and a fetched one does not, so the inline one has to win. With neither present it called `fetch(undefined)`, which requests the wallet's own origin and renders the wallet's markup as the credential's artwork. Now requires an `https` url before fetching and rejects a non-ok response, so an error page can't become artwork either.

**`forEach` doesn't await an async callback.** Displays were pushed in completion order, so a fetched template landed after an inline one declared later and the carousel order didn't match the credential. Resolved together and pushed in declaration order.

**One failing template took the whole tab down.** Failure is now contained per render method and reported, so the rest still render.

`useRenderTemplate2023` and `useHtmlRenderMethod` are inlined — both were one-line pushes, and returning a display instead of pushing one is what makes the ordering fix work.

## Verification

This branch has no test harness, so I mounted the component against the vitest harness from #142. 7 of the 8 behaviours fail before this change and all 8 pass after. The eighth is the HTML render method itself, which passes both ways and is untouched.

`eslint components/CredentialDetailsViews.vue` clean.
